### PR TITLE
SharedReader refactor, ClassLayout/ExportedType row support

### DIFF
--- a/Reemit.Common/SharedReader.cs
+++ b/Reemit.Common/SharedReader.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+
 namespace Reemit.Common;
 
 // TODO: Consider allowing SharedReader to be used lock-free
@@ -11,122 +13,41 @@ public class SharedReader(int startOffset, BinaryReader reader, object lockObj) 
 
     public int RelativeOffset => Offset - _startOffset;
 
-    public override long ReadInt64()
+    private T ReadUnmanaged<T>(Func<T> readFunc)
+        where T : unmanaged =>
+        ReadUnmanaged(readFunc, Marshal.SizeOf<T>);
+
+    private T ReadUnmanaged<T>(Func<T> readFunc, Func<int> getSizeFunc)
     {
         lock (lockObj)
         {
             var offsetCopy = BaseStream.Position;
             BaseStream.Seek(Offset, SeekOrigin.Begin);
-            var value = base.ReadInt64();
+            var value = readFunc();
             BaseStream.Seek(offsetCopy, SeekOrigin.Begin);
-            Offset += sizeof(long);
+            Offset += getSizeFunc();
             return value;
         }
     }
 
-    public override int ReadInt32()
-    {
-        lock (lockObj)
-        {
-            var offsetCopy = BaseStream.Position;
-            BaseStream.Seek(Offset, SeekOrigin.Begin);
-            var value = base.ReadInt32();
-            BaseStream.Seek(offsetCopy, SeekOrigin.Begin);
-            Offset += sizeof(int);
-            return value;
-        }
-    }
+    public override long ReadInt64() => ReadUnmanaged(base.ReadInt64);
+
+    public override int ReadInt32() => ReadUnmanaged(base.ReadInt32);
     
-    public override short ReadInt16()
-    {
-        lock (lockObj)
-        {
-            var offsetCopy = BaseStream.Position;
-            BaseStream.Seek(Offset, SeekOrigin.Begin);
-            var value = base.ReadInt16();
-            BaseStream.Seek(offsetCopy, SeekOrigin.Begin);
-            Offset += sizeof(short);
-            return value;
-        }
-    }
+    public override short ReadInt16() => ReadUnmanaged(base.ReadInt16);
     
-    public override ulong ReadUInt64()
-    {
-        lock (lockObj)
-        {
-            var offsetCopy = BaseStream.Position;
-            BaseStream.Seek(Offset, SeekOrigin.Begin);
-            var value = base.ReadUInt64();
-            BaseStream.Seek(offsetCopy, SeekOrigin.Begin);
-            Offset += sizeof(ulong);
-            return value;
-        }
-    }
+    public override ulong ReadUInt64() => ReadUnmanaged(base.ReadUInt64);
 
-    public override uint ReadUInt32()
-    {
-        lock (lockObj)
-        {
-            var offsetCopy = BaseStream.Position;
-            BaseStream.Seek(Offset, SeekOrigin.Begin);
-            var value = base.ReadUInt32();
-            BaseStream.Seek(offsetCopy, SeekOrigin.Begin);
-            Offset += sizeof(uint);
-            return value;
-        }
-    }
+    public override uint ReadUInt32() => ReadUnmanaged(base.ReadUInt32);
     
-    public override ushort ReadUInt16()
-    {
-        lock (lockObj)
-        {
-            var offsetCopy = BaseStream.Position;
-            BaseStream.Seek(Offset, SeekOrigin.Begin);
-            var value = base.ReadUInt16();
-            BaseStream.Seek(offsetCopy, SeekOrigin.Begin);
-            Offset += sizeof(ushort);
-            return value;
-        }
-    }
+    public override ushort ReadUInt16() => ReadUnmanaged(base.ReadUInt16);
 
-    public override byte[] ReadBytes(int count)
-    {
-        lock (lockObj)
-        {
-            var offsetCopy = BaseStream.Position;
-            BaseStream.Seek(Offset, SeekOrigin.Begin);
-            var value = base.ReadBytes(count);
-            BaseStream.Seek(offsetCopy, SeekOrigin.Begin);
-            Offset += sizeof(byte) * count;
-            return value;
-        }
-    }
+    public override byte[] ReadBytes(int count) =>
+        ReadUnmanaged(() => base.ReadBytes(count), () => sizeof(byte) * count);
 
-    public override char ReadChar()
-    {
-        lock (lockObj)
-        {
-            var offsetCopy = BaseStream.Position;
-            BaseStream.Seek(Offset, SeekOrigin.Begin);
-            var value = base.ReadChar();
-            BaseStream.Seek(offsetCopy, SeekOrigin.Begin);
-            Offset += sizeof(char);
-            return value;
-        }
-    }
+    public override char ReadChar() => ReadUnmanaged(base.ReadChar);
 
-    public override byte ReadByte()
-    {
-        lock (lockObj)
-        {
-            var offsetCopy = BaseStream.Position;
-            BaseStream.Seek(Offset, SeekOrigin.Begin);
-            var value = base.ReadByte();
-            BaseStream.Seek(offsetCopy, SeekOrigin.Begin);
-            Offset += sizeof(byte);
-            return value;
-        }
-    }
+    public override byte ReadByte() => ReadUnmanaged(base.ReadByte);
 
     public SharedReader CreateDerivedAtRelativeOffset(uint relativeOffset) => new((int)(_startOffset + relativeOffset), this, lockObj);
 }

--- a/Reemit.Decompiler.Clr/Metadata/CodedIndex.cs
+++ b/Reemit.Decompiler.Clr/Metadata/CodedIndex.cs
@@ -25,6 +25,14 @@ public class CodedIndex
                 ]
             },
             {
+                CodedIndexTagFamily.Implementation,
+                [
+                    MetadataTableName.File,
+                    MetadataTableName.AssemblyRef,
+                    MetadataTableName.ExportedType
+                ]
+            },
+            {
                 CodedIndexTagFamily.ResolutionScope,
                 [
                     MetadataTableName.Module,

--- a/Reemit.Decompiler.Clr/Metadata/Streams/MetadataTablesStream.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Streams/MetadataTablesStream.cs
@@ -18,6 +18,8 @@ public class MetadataTablesStream
     public MetadataTable<TypeRefRow>? TypeRef { get; }
     public MetadataTable<TypeDefRow>? TypeDef { get; }
     public MetadataTable<FieldRow>? Field { get; }
+    public MetadataTable<ClassLayoutRow>? ClassLayout { get; }
+    public MetadataTable<ExportedTypeRow>? ExportedType { get; }
 
     private readonly Dictionary<MetadataTableName, uint> _rowsCounts;
     private readonly MetadataTableDataReader _metadataTableDataReader;
@@ -52,6 +54,8 @@ public class MetadataTablesStream
         TypeRef = ReadTableIfExists<TypeRefRow>(MetadataTableName.TypeRef);
         TypeDef = ReadTableIfExists<TypeDefRow>(MetadataTableName.TypeDef);
         Field = ReadTableIfExists<FieldRow>(MetadataTableName.Field);
+        ClassLayout = ReadTableIfExists<ClassLayoutRow>(MetadataTableName.ClassLayout);
+        ExportedType = ReadTableIfExists<ExportedTypeRow>(MetadataTableName.ExportedType);
     }
 
     private MetadataTable<T>? ReadTableIfExists<T>(MetadataTableName name) where T : IMetadataTableRow, new() =>

--- a/Reemit.Decompiler.Clr/Metadata/Tables/ClassLayoutRow.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/ClassLayoutRow.cs
@@ -1,0 +1,17 @@
+﻿using Reemit.Decompiler.Clr.Metadata.Tables;
+
+namespace Reemit.Decompiler.Clr.Metadata.Tables;
+
+public class ClassLayoutRow : IMetadataTableRow
+{
+    public ushort PackingSize { get; private set; }
+    public uint ClassSize { get; private set; }
+    public uint Parent { get; private set; }
+
+    public void Read(MetadataTableDataReader reader)
+    {
+        PackingSize = reader.ReadUInt16();
+        ClassSize = reader.ReadUInt32();
+        Parent = reader.ReadRidIntoTable(MetadataTableName.TypeDef);
+    }
+}

--- a/Reemit.Decompiler.Clr/Metadata/Tables/ExportedTypeRow.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/ExportedTypeRow.cs
@@ -1,0 +1,19 @@
+﻿namespace Reemit.Decompiler.Clr.Metadata.Tables;
+
+public class ExportedTypeRow : IMetadataTableRow
+{
+    public TypeAttributes Flags { get; private set; }
+    public uint TypeDefId { get; private set; }
+    public uint TypeName { get; private set; }
+    public uint TypeNamespace { get; private set; }
+    public CodedIndex Implementation { get; private set; } = null!;
+
+    public void Read(MetadataTableDataReader reader)
+    {
+        Flags = (TypeAttributes)(reader.ReadUInt32() & FlagMasks.TypeAttributesMask);
+        TypeDefId = reader.ReadRidIntoTable(MetadataTableName.TypeDef);
+        TypeName = reader.ReadStringRid();
+        TypeNamespace = reader.ReadStringRid();
+        Implementation = reader.ReadCodedRid(CodedIndexTagFamily.Implementation);
+    }
+}


### PR DESCRIPTION
This is probably best considered draft as I am still familiarizing myself with ECMA-335 and this codebase. The PR consists of two sets of changes:

1) The `SharedReader` refactor I mentioned.
2) Added parsing of `ClassLayout` and `ExportedType` rows.

The first change I am reasonably confident in, but test coverage is sparse. The second change, not so much. I did not have a means of debugging them beyond running `MetadataTablesStreamTests`, and cannot yet say I fully understand the types in place, so like I said, probably best considered draft.