### PR TITLE
Shared reader refactor

### DIFF
--- a/Reemit.Common.UnitTests/SharedReaderTests.cs
+++ b/Reemit.Common.UnitTests/SharedReaderTests.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;

--- a/Reemit.Common.UnitTests/SharedReaderTests.cs
+++ b/Reemit.Common.UnitTests/SharedReaderTests.cs
@@ -24,7 +24,6 @@ public sealed class SharedReaderTests
         Assert.Equal(sharedReaderOffset + readBytesCount, sharedReader.Offset);
         Assert.Equal(readBytesCount, sharedReader.RelativeOffset);
         Assert.Equal(readBytesCount, actualBytes.Length);
-        Assert.NotNull(actualBytes);
         Assert.Equal([0x1, 0x2], actualBytes);
     }
 
@@ -82,10 +81,9 @@ public sealed class SharedReaderTests
         using var stream = new MemoryStream(bytes);
         using var binaryReader = new BinaryReader(stream);
         using var sharedReader = new SharedReader(sharedReaderOffset, binaryReader, new object());
-
-        // Act
         var actualUnmanagedValues = new T[expectedUnmanagedValues.Length];
 
+        // Act
         for (var i = 0; i < actualUnmanagedValues.Length; i++)
         {
             actualUnmanagedValues[i] = readUnmanaged(sharedReader);

--- a/Reemit.Common.UnitTests/SharedReaderTests.cs
+++ b/Reemit.Common.UnitTests/SharedReaderTests.cs
@@ -1,6 +1,5 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 namespace Reemit.Common.UnitTests;
 
@@ -34,7 +33,7 @@ public sealed class SharedReaderTests
         where T : unmanaged
     {
         // Arrange
-        var size = Marshal.SizeOf<T>();
+        var size = Unsafe.SizeOf<T>();
 
         var getBytes =
             typeof(T) != typeof(byte) ?
@@ -73,10 +72,9 @@ public sealed class SharedReaderTests
             CreatedReadUnmanagedTestCases(
                 new byte[] { 0xef, 0xbe, 0xad, 0xde },
                 r => r.ReadByte()),
-            // Doesn't work--need to figure out exactly how SharedReader.ReadChar should behave.
-            //CreatedReadUnmanagedTestCases(
-            //    "Hello world".ToCharArray(),
-            //    r => r.ReadChar()),
+            CreatedReadUnmanagedTestCases(
+                "Hello world".ToCharArray(),
+                r => r.ReadChar()),
             CreatedReadUnmanagedTestCases(
                 new ushort[] { 0xdead, 0xbeef, 0x5230, 0x1592, ushort.MinValue, ushort.MaxValue },
                 r => r.ReadUInt16()),

--- a/Reemit.Common.UnitTests/SharedReaderTests.cs
+++ b/Reemit.Common.UnitTests/SharedReaderTests.cs
@@ -1,5 +1,7 @@
+using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace Reemit.Common.UnitTests;
 
@@ -17,11 +19,34 @@ public sealed class SharedReaderTests
         const int readBytesCount = 2;
         
         // Act
-        sharedReader.ReadBytes(readBytesCount);
+        var actualBytes = sharedReader.ReadBytes(readBytesCount);
         
         // Assert
         Assert.Equal(sharedReaderOffset + readBytesCount, sharedReader.Offset);
         Assert.Equal(readBytesCount, sharedReader.RelativeOffset);
+        Assert.Equal(readBytesCount, actualBytes.Length);
+        Assert.NotNull(actualBytes);
+        Assert.Equal([0x1, 0x2], actualBytes);
+    }
+
+    [Fact]
+    public void ReadBytes_Called_EmptyBufferKeepsRelativeOffsetAndOffset ()
+    {
+        // Arrange
+        byte[] bytes = [];
+        using var stream = new MemoryStream(bytes);
+        using var binaryReader = new BinaryReader(stream);
+        const int sharedReaderOffset = 1;
+        using var sharedReader = new SharedReader(sharedReaderOffset, binaryReader, new object());
+        const int readBytesCount = 0x100;
+
+        // Act
+        var actualBytes = sharedReader.ReadBytes(readBytesCount);
+
+        // Assert
+        Assert.Equal(sharedReaderOffset, sharedReader.Offset);
+        Assert.Equal(0, sharedReader.RelativeOffset);
+        Assert.Equal([], actualBytes);
     }
 
     [Theory]
@@ -33,17 +58,24 @@ public sealed class SharedReaderTests
         where T : unmanaged
     {
         // Arrange
-        var size = Unsafe.SizeOf<T>();
-
         var getBytes =
-            typeof(T) != typeof(byte) ?
+            typeof(T) == typeof(byte) ?
+                x => [Unsafe.As<T, byte>(ref x)] :
+            typeof(T) == typeof(char) ?
+                x => Encoding.UTF8.GetBytes(Unsafe.As<T, char>(ref x).ToString()) :
                 typeof(BitConverter)
                     .GetMethod(
                         nameof(BitConverter.GetBytes),
                         BindingFlags.Public | BindingFlags.Static,
                         [typeof(T)])!
-                    .CreateDelegate<Func<T, byte[]>>() :
-            x => [Unsafe.As<T, byte>(ref x)];
+                    .CreateDelegate<Func<T, byte[]>>();
+
+        // We're going to assume every char is 1 byte. Technically not correct
+        // since chars are UTF-8, but we're only testing single byte chars 
+        // with this function. I could revert to Marshal.SizeOf here as that
+        // returns 1 for char, but that's not really "correct" as it's intended
+        // for interop.
+        var size = typeof(T) != typeof(char) ? Unsafe.SizeOf<T>() : 1;
 
         var expectedBytes = expectedUnmanagedValues.SelectMany(getBytes).ToArray();
         var bytes = new byte[sharedReaderOffset].Concat(expectedBytes).ToArray();
@@ -74,6 +106,9 @@ public sealed class SharedReaderTests
                 r => r.ReadByte()),
             CreatedReadUnmanagedTestCases(
                 "Hello world".ToCharArray(),
+                r => r.ReadChar()),
+            CreatedReadUnmanagedTestCases(
+                "\x00\x01\x02\x03\x04\x05\x06".ToCharArray(),
                 r => r.ReadChar()),
             CreatedReadUnmanagedTestCases(
                 new ushort[] { 0xdead, 0xbeef, 0x5230, 0x1592, ushort.MinValue, ushort.MaxValue },
@@ -110,4 +145,74 @@ public sealed class SharedReaderTests
                         expectedUnmanagedValues.Take(x).ToArray(),
                         readUnmanaged
                     }));
+
+    [Theory]
+    [MemberData(nameof(GetNotImplementedData))]
+    public void UnimplementedRead_Called_ThrowsNotImplementedException<T>(Action<SharedReader> readAction)
+    {
+        // Arrange
+        using var stream = new MemoryStream();
+        using var binaryReader = new BinaryReader(stream);
+        using var sharedReader = new SharedReader(0, binaryReader, new object());
+
+        // Act
+        var act = () => readAction(sharedReader);
+
+        // Assert
+        Assert.Throws<NotImplementedException>(act);
+    }
+
+    public static IEnumerable<object[]> GetNotImplementedData() =>
+    [
+        CreateNotImplementedTestCase(x => x.Read(new byte[0], 0, 0)),
+        CreateNotImplementedTestCase(x => x.Read(new char[0], 0, 0)),
+        CreateNotImplementedTestCase(x => x.Read(Span<byte>.Empty)),
+        CreateNotImplementedTestCase(x => x.Read(Span<char>.Empty)),
+        CreateNotImplementedTestCase(x => x.ReadBoolean()),
+        CreateNotImplementedTestCase(x => x.ReadChars(0)),
+        CreateNotImplementedTestCase(x => x.ReadDecimal()),
+        CreateNotImplementedTestCase(x => x.ReadDouble()),
+        CreateNotImplementedTestCase(x => x.ReadHalf()),
+        CreateNotImplementedTestCase(x => x.ReadSByte()),
+        CreateNotImplementedTestCase(x => x.ReadSingle()),
+        CreateNotImplementedTestCase(x => x.ReadString()),
+    ];
+
+    private static object[] CreateNotImplementedTestCase(Action<SharedReader> readAction) => [readAction];
+
+    [Fact]
+    public void SynchronizationObject_Get_EqualsConstructorArgument()
+    {
+        // Arrange
+        using var stream = new MemoryStream();
+        using var binaryReader = new BinaryReader(stream);
+        var syncObject = new object();
+        using var sharedReader = new SharedReader(1, binaryReader, syncObject);
+
+        // Act
+        var actualSyncObject = sharedReader.SynchronizationObject;
+
+        // Assert
+        Assert.Equal(syncObject, actualSyncObject);
+    }
+
+    [Fact]
+    public void CreateDerivedAtRelativeOffset_Called_RelativeOffsetSet()
+    {
+        // Arrange
+        using var stream = new MemoryStream();
+        using var binaryReader = new BinaryReader(stream);
+        const int sharedReaderOffset = 1;
+        using var sharedReader = new SharedReader(sharedReaderOffset, binaryReader, new object());
+        const int derivedSharedReaderOffset = 2;
+
+        // Act
+        var actualDerivedSharedReader = sharedReader.CreateDerivedAtRelativeOffset(derivedSharedReaderOffset);
+
+        // Assert
+        Assert.Equal(sharedReaderOffset, sharedReader.Offset);
+        Assert.Equal(0, sharedReader.RelativeOffset);
+        Assert.Equal(sharedReaderOffset + derivedSharedReaderOffset, actualDerivedSharedReader.Offset);
+        Assert.Equal(0, actualDerivedSharedReader.RelativeOffset);
+    }
 }

--- a/Reemit.Common.UnitTests/SharedReaderTests.cs
+++ b/Reemit.Common.UnitTests/SharedReaderTests.cs
@@ -1,3 +1,7 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
 namespace Reemit.Common.UnitTests;
 
 public sealed class SharedReaderTests
@@ -20,4 +24,92 @@ public sealed class SharedReaderTests
         Assert.Equal(sharedReaderOffset + readBytesCount, sharedReader.Offset);
         Assert.Equal(readBytesCount, sharedReader.RelativeOffset);
     }
+
+    [Theory]
+    [MemberData(nameof(GetReadUnmanagedData))]
+    public void ReadUnmanaged_Called_AdvancesRelativeOffsetAndOffset<T>(
+        int sharedReaderOffset,
+        T[] expectedUnmanagedValues,
+        Func<SharedReader, T> readUnmanaged)
+        where T : unmanaged
+    {
+        // Arrange
+        var size = Marshal.SizeOf<T>();
+
+        var getBytes =
+            typeof(T) != typeof(byte) ?
+                typeof(BitConverter)
+                    .GetMethod(
+                        nameof(BitConverter.GetBytes),
+                        BindingFlags.Public | BindingFlags.Static,
+                        [typeof(T)])!
+                    .CreateDelegate<Func<T, byte[]>>() :
+            x => [Unsafe.As<T, byte>(ref x)];
+
+        var expectedBytes = expectedUnmanagedValues.SelectMany(getBytes).ToArray();
+        var bytes = new byte[sharedReaderOffset].Concat(expectedBytes).ToArray();
+
+        using var stream = new MemoryStream(bytes);
+        using var binaryReader = new BinaryReader(stream);
+        using var sharedReader = new SharedReader(sharedReaderOffset, binaryReader, new object());
+
+        // Act
+        var actualUnmanagedValues = new T[expectedUnmanagedValues.Length];
+
+        for (var i = 0; i < actualUnmanagedValues.Length; i++)
+        {
+            actualUnmanagedValues[i] = readUnmanaged(sharedReader);
+        }
+
+        // Assert
+        Assert.Equal(expectedUnmanagedValues, actualUnmanagedValues);
+        Assert.Equal(sharedReaderOffset + actualUnmanagedValues.Length * size, sharedReader.Offset);
+        Assert.Throws<EndOfStreamException>(() => sharedReader.ReadByte());
+    }
+
+    public static IEnumerable<object[]> GetReadUnmanagedData() =>
+        new[]
+        {
+            CreatedReadUnmanagedTestCases(
+                new byte[] { 0xef, 0xbe, 0xad, 0xde },
+                r => r.ReadByte()),
+            // Doesn't work--need to figure out exactly how SharedReader.ReadChar should behave.
+            //CreatedReadUnmanagedTestCases(
+            //    "Hello world".ToCharArray(),
+            //    r => r.ReadChar()),
+            CreatedReadUnmanagedTestCases(
+                new ushort[] { 0xdead, 0xbeef, 0x5230, 0x1592, ushort.MinValue, ushort.MaxValue },
+                r => r.ReadUInt16()),
+            CreatedReadUnmanagedTestCases(
+                new uint[] { 0xdeadbeef, 0xcafebabe, 0xcdcdcdcd, 0xc0c0c0c0, uint.MinValue, uint.MaxValue },
+                r => r.ReadUInt32()),
+            CreatedReadUnmanagedTestCases(
+                new ulong[] { 0xdeadbeefcafebabe, 0xcdcdcdcdcdcdcdcd, 0xc0c0c0c0c0c0c0c0, 0xffffffffffffffff, ulong.MinValue, uint.MaxValue },
+                r => r.ReadUInt64()),
+            CreatedReadUnmanagedTestCases(
+                new short[] { 123, 456, 789, 1011, short.MinValue, short.MaxValue },
+                r => r.ReadInt16()),
+            CreatedReadUnmanagedTestCases(
+                new int[] { 12345, 678910, 1112131415, 1617181920, int.MinValue, int.MaxValue },
+                r => r.ReadInt32()),
+            CreatedReadUnmanagedTestCases(
+                new long[] { 123456789101112, 131415161718192021, 222324252627282930, 313233343536373839, long.MinValue, int.MaxValue },
+                r => r.ReadInt64()),
+        }
+        .SelectMany(x => x);
+
+    private static IEnumerable<object[]> CreatedReadUnmanagedTestCases<T>(
+        T[] expectedUnmanagedValues,
+        Func<SharedReader, T> readUnmanaged)
+        where T : unmanaged =>
+        Enumerable
+            .Range(1, expectedUnmanagedValues.Length)
+            .SelectMany(x =>
+                new[] { 0, 1, 512 }
+                    .Select(y => new object[]
+                    {
+                        y,
+                        expectedUnmanagedValues.Take(x).ToArray(),
+                        readUnmanaged
+                    }));
 }

--- a/Reemit.Common/SharedReader.cs
+++ b/Reemit.Common/SharedReader.cs
@@ -1,5 +1,3 @@
-using System.Runtime.CompilerServices;
-
 namespace Reemit.Common;
 
 // TODO: Consider allowing SharedReader to be used lock-free

--- a/Reemit.Common/SharedReader.cs
+++ b/Reemit.Common/SharedReader.cs
@@ -50,4 +50,28 @@ public class SharedReader(int startOffset, BinaryReader reader, object lockObj) 
     public override byte ReadByte() => ReadUnmanaged(base.ReadByte);
 
     public SharedReader CreateDerivedAtRelativeOffset(uint relativeOffset) => new((int)(_startOffset + relativeOffset), this, lockObj);
+
+    public override int Read(byte[] buffer, int index, int count) => throw new NotImplementedException();
+
+    public override int Read(char[] buffer, int index, int count) => throw new NotImplementedException();
+
+    public override int Read(Span<byte> buffer) => throw new NotImplementedException();
+
+    public override int Read(Span<char> buffer) => throw new NotImplementedException();
+
+    public override bool ReadBoolean() => throw new NotImplementedException();
+
+    public override char[] ReadChars(int count) => throw new NotImplementedException();
+
+    public override decimal ReadDecimal() => throw new NotImplementedException();
+
+    public override double ReadDouble() => throw new NotImplementedException();
+
+    public override Half ReadHalf() => throw new NotImplementedException();
+
+    public override sbyte ReadSByte() => throw new NotImplementedException();
+
+    public override float ReadSingle() => throw new NotImplementedException();
+
+    public override string ReadString() => throw new NotImplementedException();
 }

--- a/Reemit.Common/SharedReader.cs
+++ b/Reemit.Common/SharedReader.cs
@@ -1,4 +1,4 @@
-using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 
 namespace Reemit.Common;
 
@@ -15,7 +15,7 @@ public class SharedReader(int startOffset, BinaryReader reader, object lockObj) 
 
     private T ReadUnmanaged<T>(Func<T> readFunc)
         where T : unmanaged =>
-        ReadUnmanaged(readFunc, Marshal.SizeOf<T>);
+        ReadUnmanaged(readFunc, Unsafe.SizeOf<T>);
 
     private T ReadUnmanaged<T>(Func<T> readFunc, Func<int> getSizeFunc)
     {


### PR DESCRIPTION
Sending the `SharedReader` refactor as well as some pretty extensive unit test coverage that uses XUnit's `Theory` to cover all primitives with a large number of corner cases. Perhaps a little over the top, but it sucks to have subtle issues in foundational types like this. Speaking of, that's actually why this PR is marked as draft. It turns out I had a bug in my refactor of `SharedReader.ReadChar`. I had used `Marshal.SizeOf<T>` in place of the `sizeof(T)` expressions, which returns a different value when passed `char` (`Marshal` returns `1` while `sizeof` returns `2`). Not to mention `Marshal` is intended for interop, so not exactly appropriate.

I've fixed this, but it made me realize there's a subtle issue in `ReadChar`: the current implementation always increases the offset by `2`, when the actual size of the `char` is based on the `Encoder` used by the underlying `BinaryReader`. By default utf8 is used, which is variable width. We could use `BaseStream.Position` to keep track of the actual size of the `char` read, but given the purpose of this type, it makes me wonder if `ReadChar` (or any of the `BinaryReader` encoder influenced methods) is even suitable. I see you already have some extensions for reading strings; allowing callers to dictate how the bytes are interpreted seems like a better approach here.

Finally, I've added overrides for most of the remaining `BinaryReader` functions to throw `NotImplementedException` in case of accidental use, as these would not update `Offset` and could cause subtle errors. The only one of note not overridden is `BinaryReader.Read()`, as `BinaryReader.ReadChar()` calls into this. Not really sure how to handle that one until a call on `ReadChar` is made.