### PR TITLE
Add opening modules with open file dialog and drag and drop

### DIFF
--- a/Reemit.Decompiler.Clr/Metadata/Streams/MetadataTablesStream.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Streams/MetadataTablesStream.cs
@@ -13,7 +13,7 @@ public class MetadataTablesStream
     public HeapSizes HeapSizes { get; }
     public byte Reserved1 { get; }
 
-    public MetadataTable<ModuleRow>? Module { get; }
+    public MetadataTable<ModuleRow> Module { get; }
     public MetadataTable<TypeRefRow>? TypeRef { get; }
     public MetadataTable<TypeDefRow>? TypeDef { get; }
     public MetadataTable<FieldRow>? Field { get; }
@@ -45,7 +45,16 @@ public class MetadataTablesStream
 
         _metadataTableDataReader = new MetadataTableDataReader(reader, HeapSizes, _rowsCounts);
 
-        Module = ReadTableIfExists<ModuleRow>();
+        var moduleTable = ReadTableIfExists<ModuleRow>();
+        
+        // From II.22.30, informative text entry 1: The Module table shall contain one and only one row [ERROR]
+        if (moduleTable is not { Rows.Count: 1 })
+        {
+            throw new BadImageFormatException("The Module table shall contain one and only one row");
+        }
+
+        Module = moduleTable;
+
         TypeRef = ReadTableIfExists<TypeRefRow>();
         TypeDef = ReadTableIfExists<TypeDefRow>();
         Field = ReadTableIfExists<FieldRow>();

--- a/Reemit.Decompiler/ClrModule.cs
+++ b/Reemit.Decompiler/ClrModule.cs
@@ -46,11 +46,6 @@ public class ClrModule
 
         var types = metadataStream.TypeDef?.Rows.Select(x => ClrType.FromTypeDefRow(x, context)).ToArray().AsReadOnly();
 
-        if (metadataStream.Module is null)
-        {
-            throw new BadImageFormatException("The module table is undefined in this image");
-        }
-
         var name = stringsStream.Read(metadataStream.Module.Rows[0].Name);
 
         return new ClrModule(name, types);

--- a/Reemit.Decompiler/ClrModule.cs
+++ b/Reemit.Decompiler/ClrModule.cs
@@ -9,14 +9,27 @@ public class ClrModule
     public string Name { get; }
     public IReadOnlyList<ClrType>? Types { get; }
 
-    public ClrModule(string fileName)
+    private ClrModule(string name, IReadOnlyList<ClrType>? types)
+    {
+        Name = name;
+        Types = types;
+    }
+
+    public static ClrModule Open(string fileName)
     {
         var fileStream = new FileStream(fileName, FileMode.Open);
         var peFile = new PEFile(new BinaryReader(fileStream));
 
-        var clrRuntimeHeaderDir = peFile.DataDirectories[14];
+        const int clrHeaderDirIndex = 14;
+
+        if (peFile.DataDirectories.Count - 1 < clrHeaderDirIndex)
+        {
+            throw new BadImageFormatException("This image does not have a CLR header");
+        }
+
+        var clrRuntimeHeaderDir = peFile.DataDirectories[clrHeaderDirIndex];
         var clrRuntimeHeader = peFile.GetStructureDescribedByDataDirectory<CliHeader>(clrRuntimeHeaderDir);
-        
+
         var metadataOffset = peFile.GetFileOffset(clrRuntimeHeader.Metadata.VirtualAddress);
         var metadataReader = peFile.CreateReaderAt(metadataOffset);
         var metadata = new MetadataRoot(metadataReader);
@@ -24,18 +37,25 @@ public class ClrModule
         var stringsStreamHeader = metadata.StreamHeaders.Single(x => x.Name == StringsHeapStream.Name);
         var stringsStreamOffset = metadataOffset + stringsStreamHeader.Offset;
         var stringsStream = new StringsHeapStream(peFile.CreateReaderAt(stringsStreamOffset), stringsStreamHeader);
-        
+
         var metadataStreamHeader = metadata.StreamHeaders.Single(x => x.Name == MetadataTablesStream.Name);
         var metadataStreamOffset = metadataOffset + metadataStreamHeader.Offset;
         var metadataStream = new MetadataTablesStream(peFile.CreateReaderAt(metadataStreamOffset));
 
         var context = new ClrMetadataContext(metadataStream, stringsStream);
 
-        Types = metadataStream.TypeDef?.Rows.Select(x => ClrType.FromTypeDefRow(x, context)).ToArray().AsReadOnly();
+        var types = metadataStream.TypeDef?.Rows.Select(x => ClrType.FromTypeDefRow(x, context)).ToArray().AsReadOnly();
 
-        if (metadataStream.Module is not null)
+        if (metadataStream.Module is null)
         {
-            Name = stringsStream.Read(metadataStream.Module.Rows[0].Name);
+            throw new BadImageFormatException("The module table is undefined in this image");
         }
+
+        var name = stringsStream.Read(metadataStream.Module.Rows[0].Name);
+
+        return new ClrModule(name, types);
     }
+
+    public string DebugDump() =>
+        $"Module: {Name}, Types: {string.Join(", ", Types?.Select(x => x.Name) ?? Array.Empty<string>())}";
 }

--- a/Reemit.Gui/Reemit.Gui.csproj
+++ b/Reemit.Gui/Reemit.Gui.csproj
@@ -22,5 +22,11 @@
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
         <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.10"/>
         <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.10"/>
+        <PackageReference Include="ReactiveUI.Fody" Version="19.5.41" />
+    </ItemGroup>
+
+
+    <ItemGroup>
+      <ProjectReference Include="..\Reemit.Decompiler\Reemit.Decompiler.csproj" />
     </ItemGroup>
 </Project>

--- a/Reemit.Gui/ViewModels/HelloViewModel.cs
+++ b/Reemit.Gui/ViewModels/HelloViewModel.cs
@@ -59,7 +59,7 @@ public class HelloViewModel : ReactiveObject, IRoutableViewModel
             Span<string> allowedExtensions = [".dll", ".exe"];
 
             var absolutePath = i.Path.AbsolutePath;
-            return allowedExtensions.Contains(Path.GetExtension(absolutePath));
+            return allowedExtensions.Contains(Path.GetExtension(absolutePath).ToLower());
         });
     }
 

--- a/Reemit.Gui/ViewModels/HelloViewModel.cs
+++ b/Reemit.Gui/ViewModels/HelloViewModel.cs
@@ -22,7 +22,7 @@ public class HelloViewModel : ReactiveObject, IRoutableViewModel
     public IReadOnlyList<IStorageItem>? FilesDraggedOver { get; set; }
 
     [ObservableAsProperty]
-    public bool IsAcceptedFileDraggedOver { get; }
+    public bool AreAcceptedFilesDraggedOver { get; }
 
     public string UrlPathSegment => nameof(HelloViewModel);
     
@@ -36,15 +36,14 @@ public class HelloViewModel : ReactiveObject, IRoutableViewModel
 
         this.WhenAnyValue(vm => vm.FilesDraggedOver)
             .Select(ShouldAcceptDraggedFiles)
-            .ToPropertyEx(this, vm => vm.IsAcceptedFileDraggedOver);
+            .ToPropertyEx(this, vm => vm.AreAcceptedFilesDraggedOver);
 
         OpenFiles = ReactiveCommand.CreateFromTask<Unit, Unit>(OpenFilesAsync);
 
-        var hasAnyDraggedOverFiles = this.WhenAnyValue(vm => vm.FilesDraggedOver)
-            .Select(x => x is { Count: > 0 });
+        var hasAcceptedFilesDraggedOver = this.WhenAnyValue(vm => vm.AreAcceptedFilesDraggedOver);
 
         OpenDroppedFiles =
-            ReactiveCommand.CreateFromTask<Unit, Unit>(OpenDroppedFilesAsync, hasAnyDraggedOverFiles);
+            ReactiveCommand.CreateFromTask<Unit, Unit>(OpenDroppedFilesAsync, hasAcceptedFilesDraggedOver);
     }
     
     private static bool ShouldAcceptDraggedFiles(IReadOnlyList<IStorageItem>? items)

--- a/Reemit.Gui/ViewModels/HelloViewModel.cs
+++ b/Reemit.Gui/ViewModels/HelloViewModel.cs
@@ -1,12 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Avalonia.Platform.Storage;
 using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
+using Reemit.Decompiler;
 
 namespace Reemit.Gui.ViewModels;
 
 public class HelloViewModel : ReactiveObject, IRoutableViewModel
 {
+    public ReactiveCommand<Unit, Unit> OpenFiles { get; }
+
+    public ReactiveCommand<Unit, Unit> OpenDroppedFiles { get; }
+
+    [Reactive]
+    public IReadOnlyList<IStorageItem>? FilesDraggedOver { get; set; }
+
+    [ObservableAsProperty]
+    public bool IsAcceptedFileDraggedOver { get; }
+
     public string UrlPathSegment => nameof(HelloViewModel);
     
     public IScreen HostScreen { get; }
 
-    public HelloViewModel(IScreen screen) => HostScreen = screen;
+    public Interaction<Unit, IReadOnlyList<IStorageItem>> ShowOpenFileDialog { get; } = new();
+
+    public HelloViewModel(IScreen hostScreen)
+    {
+        HostScreen = hostScreen;
+
+        this.WhenAnyValue(vm => vm.FilesDraggedOver)
+            .Select(ShouldAcceptDraggedFiles)
+            .ToPropertyEx(this, vm => vm.IsAcceptedFileDraggedOver);
+
+        OpenFiles = ReactiveCommand.CreateFromTask<Unit, Unit>(OpenFilesAsync);
+
+        var hasAnyDraggedOverFiles = this.WhenAnyValue(vm => vm.FilesDraggedOver)
+            .Select(x => x is { Count: > 0 });
+
+        OpenDroppedFiles =
+            ReactiveCommand.CreateFromTask<Unit, Unit>(OpenDroppedFilesAsync, hasAnyDraggedOverFiles);
+    }
+    
+    private static bool ShouldAcceptDraggedFiles(IReadOnlyList<IStorageItem>? items)
+    {
+        if (items is null)
+        {
+            return false;
+        }
+        
+        return items.All(i =>
+        {
+            Span<string> allowedExtensions = [".dll", ".exe"];
+
+            var absolutePath = i.Path.AbsolutePath;
+            return allowedExtensions.Contains(Path.GetExtension(absolutePath));
+        });
+    }
+
+    private async Task<Unit> OpenFilesAsync(Unit _)
+    {
+        var files = await ShowOpenFileDialog.Handle(Unit.Default);
+        await OpenFilesAsync(files);
+
+        return Unit.Default;
+    }
+
+    private async Task<Unit> OpenDroppedFilesAsync(Unit _)
+    {
+        await OpenFilesAsync(FilesDraggedOver!);
+
+        return Unit.Default;
+    }
+
+    private async Task OpenFilesAsync(IReadOnlyList<IStorageItem> storageItems)
+    {
+        var clrModules =
+            storageItems
+                .Select(f => f.Path.AbsolutePath)
+                .Select(ClrModule.Open)
+                .ToArray();
+
+        await HostScreen.Router.Navigate.Execute(new HomeViewModel(HostScreen, clrModules));
+    }
 }

--- a/Reemit.Gui/ViewModels/HelloViewModel.cs
+++ b/Reemit.Gui/ViewModels/HelloViewModel.cs
@@ -65,7 +65,11 @@ public class HelloViewModel : ReactiveObject, IRoutableViewModel
     private async Task<Unit> OpenFilesAsync(Unit _)
     {
         var files = await ShowOpenFileDialog.Handle(Unit.Default);
-        await OpenFilesAsync(files);
+
+        if (files.Count > 0)
+        {
+            await OpenFilesAsync(files);
+        }
 
         return Unit.Default;
     }

--- a/Reemit.Gui/ViewModels/HomeViewModel.cs
+++ b/Reemit.Gui/ViewModels/HomeViewModel.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using ReactiveUI;
+using Reemit.Decompiler;
+
+namespace Reemit.Gui.ViewModels;
+
+public class HomeViewModel : ReactiveObject, IRoutableViewModel
+{
+    public IReadOnlyList<ClrModule> Modules { get; }
+
+    public HomeViewModel(IScreen hostScreen, IReadOnlyList<ClrModule> modules)
+    {
+        Modules = modules;
+        HostScreen = hostScreen;
+    }
+
+    public string UrlPathSegment => nameof(HomeViewModel);
+    public IScreen HostScreen { get; }
+}

--- a/Reemit.Gui/Views/HelloView.axaml
+++ b/Reemit.Gui/Views/HelloView.axaml
@@ -4,19 +4,29 @@
                           xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                           xmlns:rxui="http://reactiveui.net"
                           xmlns:viewModels="clr-namespace:Reemit.Gui.ViewModels"
+                          DragDrop.AllowDrop="True"
+                          Background="Transparent"
                           mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
-                          x:Class="Reemit.Gui.Views.HelloView"
-                          HorizontalContentAlignment="Center"
-                          VerticalContentAlignment="Center">
-    <StackPanel Spacing="8">
-        <StackPanel.Styles>
-            <Style Selector="TextBlock">
-                <Setter Property="HorizontalAlignment" Value="Center" />
-            </Style>
-        </StackPanel.Styles>
-        <TextBlock FontSize="32" FontWeight="Heavy" Foreground="White">Reemit</TextBlock>
-        <TextBlock Foreground="White">Drop a .NET assembly here</TextBlock>
-        <TextBlock Foreground="White" Opacity=".5">or</TextBlock>
-        <Button Foreground="White" HorizontalAlignment="Center">Pick a file</Button>
-    </StackPanel>
+                          x:Class="Reemit.Gui.Views.HelloView">
+    <Grid>
+        <Rectangle StrokeDashArray="4, 2" Stroke="Gray" StrokeThickness="3" HorizontalAlignment="Stretch"
+                   VerticalAlignment="Stretch" Margin="8" RadiusX="16" RadiusY="16" Name="DragBorderRectangle" />
+
+        <StackPanel Spacing="8" HorizontalAlignment="Center" VerticalAlignment="Center"
+                    Name="OpenFileControlsStackPanel">
+            <StackPanel.Styles>
+                <Style Selector="TextBlock">
+                    <Setter Property="HorizontalAlignment" Value="Center" />
+                </Style>
+            </StackPanel.Styles>
+            <TextBlock FontSize="32" FontWeight="Heavy" Foreground="White">Reemit</TextBlock>
+            <TextBlock Foreground="White">Drop a .NET assembly here</TextBlock>
+            <TextBlock Foreground="White" Opacity=".5">or</TextBlock>
+            <Button Foreground="White" HorizontalAlignment="Center" Name="PickFileButton">Pick a file</Button>
+        </StackPanel>
+
+        <TextBlock Foreground="White" HorizontalAlignment="Center" VerticalAlignment="Center" Name="DropHintText">
+            Drop the assembly to open it
+        </TextBlock>
+    </Grid>
 </rxui:ReactiveUserControl>

--- a/Reemit.Gui/Views/HelloView.axaml.cs
+++ b/Reemit.Gui/Views/HelloView.axaml.cs
@@ -1,5 +1,16 @@
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using Avalonia.Input;
 using Avalonia.ReactiveUI;
+using ReactiveUI;
 using Reemit.Gui.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Platform.Storage;
 
 namespace Reemit.Gui.Views;
 
@@ -8,5 +19,83 @@ public partial class HelloView : ReactiveUserControl<HelloViewModel>
     public HelloView()
     {
         InitializeComponent();
+
+        this.WhenActivated(disposable =>
+        {
+            this.OneWayBind(ViewModel, vm => vm.IsAcceptedFileDraggedOver, v => v.DragBorderRectangle.IsVisible)
+                .DisposeWith(disposable);
+
+            this.OneWayBind(ViewModel, vm => vm.IsAcceptedFileDraggedOver, v => v.OpenFileControlsStackPanel.IsVisible,
+                    v => !v)
+                .DisposeWith(disposable);
+
+            this.OneWayBind(ViewModel, vm => vm.IsAcceptedFileDraggedOver, v => v.DropHintText.IsVisible)
+                .DisposeWith(disposable);
+
+            this.BindCommand(ViewModel, vm => vm.OpenFiles, v => v.PickFileButton)
+                .DisposeWith(disposable);
+
+            ViewModel?.ShowOpenFileDialog.RegisterHandler(HandleShowOpenFileDialog)
+                .DisposeWith(disposable);
+
+            Observable.FromEventPattern<DragEventArgs>(
+                    handler => AddHandler(DragDrop.DragOverEvent, handler),
+                    handler => RemoveHandler(DragDrop.DragOverEvent, handler))
+                .CombineLatest(ViewModel.WhenAnyValue(vm => vm.IsAcceptedFileDraggedOver))
+                .Subscribe(x => x.First.EventArgs.DragEffects = x.Second
+                    ? DragDropEffects.Move | DragDropEffects.Copy | DragDropEffects.Link
+                    : DragDropEffects.None)
+                .DisposeWith(disposable);
+
+            const string filesDataFormatName = "Files";
+
+            var filesDragEnterObservable = Observable.FromEventPattern<DragEventArgs>(
+                    handler => AddHandler(DragDrop.DragEnterEvent, handler),
+                    handler => RemoveHandler(DragDrop.DragLeaveEvent, handler))
+                .Select(x => x.EventArgs)
+                .Select(x => x.Data.Get(filesDataFormatName) as IEnumerable<IStorageItem>)
+                .WhereNotNull()
+                .Select(x => (IReadOnlyList<IStorageItem>)x.ToArray());
+
+            var filesDragLeaveObservable = Observable.FromEventPattern<DragEventArgs>(
+                    handler => AddHandler(DragDrop.DragLeaveEvent, handler),
+                    handler => RemoveHandler(DragDrop.DragLeaveEvent, handler))
+                .Select(_ => (IReadOnlyList<IStorageItem>?)null);
+
+            filesDragEnterObservable.Merge(filesDragLeaveObservable)
+                .BindTo(ViewModel, vm => vm.FilesDraggedOver)
+                .DisposeWith(disposable);
+
+            Observable.FromEventPattern<DragEventArgs>(
+                    handler => AddHandler(DragDrop.DropEvent, handler),
+                    handler => RemoveHandler(DragDrop.DropEvent, handler))
+                .Select(_ => Unit.Default)
+                .InvokeCommand(ViewModel, vm => vm.OpenDroppedFiles)
+                .DisposeWith(disposable);
+        });
+    }
+
+    private async Task HandleShowOpenFileDialog(
+        IInteractionContext<Unit, IReadOnlyList<IStorageItem>> interactionContext)
+    {
+        var topLevel = TopLevel.GetTopLevel(this);
+
+        if (topLevel is null)
+        {
+            throw new InvalidOperationException("The control must be attached to a visual tree");
+        }
+
+        var files = await topLevel.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = "Choose CLR module",
+            AllowMultiple = true,
+            FileTypeFilter =
+            [
+                new FilePickerFileType(".NET Module") { Patterns = ["*.dll", "*.exe"] },
+                new FilePickerFileType("All files")
+            ]
+        });
+
+        interactionContext.SetOutput(files);
     }
 }

--- a/Reemit.Gui/Views/HelloView.axaml.cs
+++ b/Reemit.Gui/Views/HelloView.axaml.cs
@@ -92,7 +92,7 @@ public partial class HelloView : ReactiveUserControl<HelloViewModel>
             FileTypeFilter =
             [
                 new FilePickerFileType(".NET Module") { Patterns = ["*.dll", "*.exe"] },
-                new FilePickerFileType("All files")
+                new FilePickerFileType("All files") { Patterns = ["*.*"] }
             ]
         });
 

--- a/Reemit.Gui/Views/HelloView.axaml.cs
+++ b/Reemit.Gui/Views/HelloView.axaml.cs
@@ -22,14 +22,14 @@ public partial class HelloView : ReactiveUserControl<HelloViewModel>
 
         this.WhenActivated(disposable =>
         {
-            this.OneWayBind(ViewModel, vm => vm.IsAcceptedFileDraggedOver, v => v.DragBorderRectangle.IsVisible)
+            this.OneWayBind(ViewModel, vm => vm.AreAcceptedFilesDraggedOver, v => v.DragBorderRectangle.IsVisible)
                 .DisposeWith(disposable);
 
-            this.OneWayBind(ViewModel, vm => vm.IsAcceptedFileDraggedOver, v => v.OpenFileControlsStackPanel.IsVisible,
+            this.OneWayBind(ViewModel, vm => vm.AreAcceptedFilesDraggedOver, v => v.OpenFileControlsStackPanel.IsVisible,
                     v => !v)
                 .DisposeWith(disposable);
 
-            this.OneWayBind(ViewModel, vm => vm.IsAcceptedFileDraggedOver, v => v.DropHintText.IsVisible)
+            this.OneWayBind(ViewModel, vm => vm.AreAcceptedFilesDraggedOver, v => v.DropHintText.IsVisible)
                 .DisposeWith(disposable);
 
             this.BindCommand(ViewModel, vm => vm.OpenFiles, v => v.PickFileButton)
@@ -41,7 +41,7 @@ public partial class HelloView : ReactiveUserControl<HelloViewModel>
             Observable.FromEventPattern<DragEventArgs>(
                     handler => AddHandler(DragDrop.DragOverEvent, handler),
                     handler => RemoveHandler(DragDrop.DragOverEvent, handler))
-                .CombineLatest(ViewModel.WhenAnyValue(vm => vm.IsAcceptedFileDraggedOver))
+                .CombineLatest(ViewModel.WhenAnyValue(vm => vm.AreAcceptedFilesDraggedOver))
                 .Subscribe(x => x.First.EventArgs.DragEffects = x.Second
                     ? DragDropEffects.Move | DragDropEffects.Copy | DragDropEffects.Link
                     : DragDropEffects.None)

--- a/Reemit.Gui/Views/HomeView.axaml
+++ b/Reemit.Gui/Views/HomeView.axaml
@@ -1,0 +1,10 @@
+<rxui:ReactiveUserControl x:TypeArguments="viewModels:HomeViewModel" xmlns="https://github.com/avaloniaui"
+                          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                          xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                          xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                          xmlns:rxui="http://reactiveui.net"
+                          xmlns:viewModels="clr-namespace:Reemit.Gui.ViewModels"
+                          mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+                          x:Class="Reemit.Gui.Views.HomeView">
+    <TextBox AcceptsReturn="True" Name="OpenAssembliesText" />
+</rxui:ReactiveUserControl>

--- a/Reemit.Gui/Views/HomeView.axaml.cs
+++ b/Reemit.Gui/Views/HomeView.axaml.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Linq;
+using System.Reactive.Disposables;
+using Avalonia.ReactiveUI;
+using ReactiveUI;
+using Reemit.Gui.ViewModels;
+
+namespace Reemit.Gui.Views;
+
+public partial class HomeView : ReactiveUserControl<HomeViewModel>
+{
+    public HomeView()
+    {
+        InitializeComponent();
+
+        this.WhenActivated(disposable =>
+        {
+            this.OneWayBind(ViewModel, vm => vm.Modules, v => v.OpenAssembliesText.Text,
+                    v => string.Join(Environment.NewLine, v.Select(x => x.DebugDump())))
+                .DisposeWith(disposable);
+        });
+    }
+}

--- a/Reemit.Gui/Views/MainWindow.axaml
+++ b/Reemit.Gui/Views/MainWindow.axaml
@@ -9,7 +9,6 @@
         x:DataType="vm:MainWindowViewModel"
         TransparencyLevelHint="AcrylicBlur"
         Background="Transparent"
-        ExtendClientAreaToDecorationsHint="True"
         Icon="/Assets/avalonia-logo.ico"
         Title="Reemit.Gui">
 


### PR DESCRIPTION
These changes add opening modules to the GUI project. This currently works both with drag'n'drop and using native open file dialog. After a module is opened, its name and names of types it contains are dumped into a TextBox. This behavior is rather a stopgap. I'll probably get rid of it in the upcoming PRs.