### PR TITLE
Refactored metadata table row interface.

### DIFF
--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Tables/FieldRowTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Tables/FieldRowTests.cs
@@ -12,10 +12,9 @@ public class FieldRowTests
         byte[] bytes = [0x01, 0x00, 0x11, 0x00, 0x1E, 0x00];
         await using var memoryStream = new MemoryStream(bytes);
         using var reader = new BinaryReader(memoryStream);
-        var row = new FieldRow();
 
         // Act
-        row.Read(new MetadataTableDataReader(reader, 0, new Dictionary<MetadataTableName, uint>()));
+        var row = FieldRow.Read(new MetadataTableDataReader(reader, 0, new Dictionary<MetadataTableName, uint>()));
         
         // Assert
         Assert.Equal(FieldAttributes.Private, row.Flags);

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Tables/ModuleRowTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Tables/ModuleRowTests.cs
@@ -12,10 +12,9 @@ public class ModuleRowTests
         byte[] bytes = [0x00, 0x00, 0x68, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00];
         await using var memoryStream = new MemoryStream(bytes);
         using var reader = new BinaryReader(memoryStream);
-        var header = new ModuleRow();
 
         // Act
-        header.Read(new MetadataTableDataReader(reader, 0, new Dictionary<MetadataTableName, uint>()));
+        var header = ModuleRow.Read(new MetadataTableDataReader(reader, 0, new Dictionary<MetadataTableName, uint>()));
         
         // Assert
         Assert.Equal([0, 0], header.Generation);

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Tables/TypeDefRowTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Tables/TypeDefRowTests.cs
@@ -12,10 +12,9 @@ public class TypeDefRowTests
         byte[] bytes = [0x01, 0x00, 0x10, 0x00, 0x01, 0x00, 0xEB, 0x01, 0x35, 0x00, 0x01, 0x00, 0x01, 0x00];
         await using var memoryStream = new MemoryStream(bytes);
         using var reader = new BinaryReader(memoryStream);
-        var row = new TypeDefRow();
 
         // Act
-        row.Read(new MetadataTableDataReader(reader, 0, new Dictionary<MetadataTableName, uint>
+        var row = TypeDefRow.Read(new MetadataTableDataReader(reader, 0, new Dictionary<MetadataTableName, uint>
         {
             { MetadataTableName.TypeRef, 1 },
             { MetadataTableName.Field, 1 },

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Tables/TypeRefRowTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Tables/TypeRefRowTests.cs
@@ -12,10 +12,9 @@ public class TypeRefRowTests
         byte[] bytes = [0x06, 0x00, 0x2B, 0x00, 0xA2, 0x01];
         await using var memoryStream = new MemoryStream(bytes);
         using var reader = new BinaryReader(memoryStream);
-        var row = new TypeRefRow();
 
         // Act
-        row.Read(new MetadataTableDataReader(reader, 0, new Dictionary<MetadataTableName, uint>
+        var row = TypeRefRow.Read(new MetadataTableDataReader(reader, 0, new Dictionary<MetadataTableName, uint>
         {
             { MetadataTableName.AssemblyRef, 1 }
         }));

--- a/Reemit.Decompiler.Clr/Metadata/Streams/MetadataTablesStream.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Streams/MetadataTablesStream.cs
@@ -51,7 +51,7 @@ public class MetadataTablesStream
         Field = ReadTableIfExists<FieldRow>();
     }
 
-    private MetadataTable<T>? ReadTableIfExists<T>() where T : IMetadataTableRow, new() =>
+    private MetadataTable<T>? ReadTableIfExists<T>() where T : IMetadataTableRow<T> =>
         !_rowsCounts.TryGetValue(T.TableName, out var count)
             ? null
             : new MetadataTable<T>(count, _metadataTableDataReader);

--- a/Reemit.Decompiler.Clr/Metadata/Tables/FieldRow.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/FieldRow.cs
@@ -1,17 +1,17 @@
 namespace Reemit.Decompiler.Clr.Metadata.Tables;
 
-public class FieldRow : IMetadataTableRow
+public class FieldRow(FieldAttributes flags, uint name, uint signature)
+    : IMetadataTableRow<FieldRow>
 {
     public static MetadataTableName TableName => MetadataTableName.Field;
 
-    public FieldAttributes Flags { get; private set; }
-    public uint Name { get; private set; }
-    public uint Signature { get; private set; }
+    public FieldAttributes Flags { get; } = flags;
+    public uint Name { get; } = name;
+    public uint Signature { get; } = signature;
 
-    public void Read(MetadataTableDataReader reader)
-    {
-        Flags = (FieldAttributes)(reader.ReadUInt16() & FlagMasks.FieldAccessMask);
-        Name = reader.ReadStringRid();
-        Signature = reader.ReadBlobRid();
-    }
+    public static FieldRow Read(MetadataTableDataReader reader) =>
+        new(
+            (FieldAttributes)(reader.ReadUInt16() & FlagMasks.FieldAccessMask),
+            reader.ReadStringRid(),
+            reader.ReadBlobRid());
 }

--- a/Reemit.Decompiler.Clr/Metadata/Tables/IMetadataTableRow.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/IMetadataTableRow.cs
@@ -3,6 +3,10 @@ namespace Reemit.Decompiler.Clr.Metadata.Tables;
 public interface IMetadataTableRow
 {
     static abstract MetadataTableName TableName { get; }
+}
 
-    void Read(MetadataTableDataReader reader);
+public interface IMetadataTableRow<T> : IMetadataTableRow
+    where T : IMetadataTableRow<T>
+{
+    static abstract T Read(MetadataTableDataReader reader);
 }

--- a/Reemit.Decompiler.Clr/Metadata/Tables/MetadataTable.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/MetadataTable.cs
@@ -1,6 +1,6 @@
 namespace Reemit.Decompiler.Clr.Metadata.Tables;
 
-public class MetadataTable<TRow> where TRow : IMetadataTableRow, new()
+public class MetadataTable<TRow> where TRow : IMetadataTableRow<TRow>
 {
     public IReadOnlyList<TRow> Rows { get; }
 
@@ -10,10 +10,7 @@ public class MetadataTable<TRow> where TRow : IMetadataTableRow, new()
 
         for (var i = 0; i < rowCount; i++)
         {
-            var row = new TRow();
-            row.Read(reader);
-
-            rows.Add(row);
+            rows.Add(TRow.Read(reader));
         }
 
         Rows = rows.AsReadOnly();

--- a/Reemit.Decompiler.Clr/Metadata/Tables/ModuleRow.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/ModuleRow.cs
@@ -1,38 +1,41 @@
 namespace Reemit.Decompiler.Clr.Metadata.Tables;
 
-public class ModuleRow : IMetadataTableRow
+public class ModuleRow(byte[] generation, uint name, uint mvid, uint encId, uint encBaseId)
+    : IMetadataTableRow<ModuleRow>
 {
     public static MetadataTableName TableName => MetadataTableName.Module;
 
-    public byte[] Generation { get; private set; } = null!;
-    public uint Name { get; private set; }
-    public uint Mvid { get; private set; }
-    public uint EncId { get; private set; }
-    public uint EncBaseId { get; private set; }
+    public byte[] Generation { get; } = generation;
+    public uint Name { get; } = name;
+    public uint Mvid { get; } = mvid;
+    public uint EncId { get; } = encId;
+    public uint EncBaseId { get; } = encBaseId;
 
-    public void Read(MetadataTableDataReader reader)
+    public static ModuleRow Read(MetadataTableDataReader reader)
     {
-        Generation = reader.ReadBytes(2);
+        var generation = reader.ReadBytes(2);
 
-        if (Generation.Any(x => x != 0))
+        if (generation.Any(x => x != 0))
         {
-            throw new BadImageFormatException($"{nameof(Generation)} shall be zero.");
+            throw new BadImageFormatException($"{nameof(generation)} shall be zero.");
         }
-        
-        Name = reader.ReadStringRid();
-        Mvid = reader.ReadGuidRid();
-        EncId = reader.ReadGuidRid();
 
-        if (EncId != 0)
-        {
-            throw new BadImageFormatException($"{nameof(EncId)} shall be zero.");
-        }
-        
-        EncBaseId = reader.ReadGuidRid();
+        var name = reader.ReadStringRid();
+        var mvid = reader.ReadGuidRid();
+        var encId = reader.ReadGuidRid();
 
-        if (EncBaseId != 0)
+        if (encId != 0)
         {
-            throw new BadImageFormatException($"{nameof(EncBaseId)} shall be zero.");
+            throw new BadImageFormatException($"{nameof(encId)} shall be zero.");
         }
+
+        var encBaseId = reader.ReadGuidRid();
+
+        if (encBaseId != 0)
+        {
+            throw new BadImageFormatException($"{nameof(encBaseId)} shall be zero.");
+        }
+
+        return new(generation, name, mvid, encId, encBaseId);
     }
 }

--- a/Reemit.Decompiler.Clr/Metadata/Tables/TypeDefRow.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/TypeDefRow.cs
@@ -11,12 +11,12 @@ public class TypeDefRow(
 {
     public static MetadataTableName TableName => MetadataTableName.TypeDef;
 
-    public TypeAttributes Flags { get; private set; } = flags;
-    public uint TypeName { get; private set; } = typeName;
-    public uint TypeNamespace { get; private set; } = typeNamespace;
-    public CodedIndex Extends { get; private set; } = extends;
-    public uint FieldList { get; private set; } = fieldList;
-    public uint MethodList { get; private set; } = methodList;
+    public TypeAttributes Flags { get; } = flags;
+    public uint TypeName { get; } = typeName;
+    public uint TypeNamespace { get; } = typeNamespace;
+    public CodedIndex Extends { get; } = extends;
+    public uint FieldList { get; } = fieldList;
+    public uint MethodList { get; } = methodList;
 
     public static TypeDefRow Read(MetadataTableDataReader reader) =>
         new(

--- a/Reemit.Decompiler.Clr/Metadata/Tables/TypeDefRow.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/TypeDefRow.cs
@@ -1,23 +1,29 @@
 namespace Reemit.Decompiler.Clr.Metadata.Tables;
 
-public class TypeDefRow : IMetadataTableRow
+public class TypeDefRow(
+    TypeAttributes flags,
+    uint typeName,
+    uint typeNamespace,
+    CodedIndex extends,
+    uint fieldList,
+    uint methodList)
+    : IMetadataTableRow<TypeDefRow>
 {
     public static MetadataTableName TableName => MetadataTableName.TypeDef;
 
-    public TypeAttributes Flags { get; private set; }
-    public uint TypeName { get; private set; }
-    public uint TypeNamespace { get; private set; }
-    public CodedIndex Extends { get; private set; } = null!;
-    public uint FieldList { get; private set; }
-    public uint MethodList { get; private set; }
+    public TypeAttributes Flags { get; private set; } = flags;
+    public uint TypeName { get; private set; } = typeName;
+    public uint TypeNamespace { get; private set; } = typeNamespace;
+    public CodedIndex Extends { get; private set; } = extends;
+    public uint FieldList { get; private set; } = fieldList;
+    public uint MethodList { get; private set; } = methodList;
 
-    public void Read(MetadataTableDataReader reader)
-    {
-        Flags = (TypeAttributes)(reader.ReadUInt32() & FlagMasks.TypeAttributesMask);
-        TypeName = reader.ReadStringRid();
-        TypeNamespace = reader.ReadStringRid();
-        Extends = reader.ReadCodedRid(CodedIndexTagFamily.TypeDefOrRef);
-        FieldList = reader.ReadRidIntoTable(MetadataTableName.Field);
-        MethodList = reader.ReadRidIntoTable(MetadataTableName.MethodDef);
-    }
+    public static TypeDefRow Read(MetadataTableDataReader reader) =>
+        new(
+            (TypeAttributes)(reader.ReadUInt32() & FlagMasks.TypeAttributesMask),
+            reader.ReadStringRid(),
+            reader.ReadStringRid(),
+            reader.ReadCodedRid(CodedIndexTagFamily.TypeDefOrRef),
+            reader.ReadRidIntoTable(MetadataTableName.Field),
+            reader.ReadRidIntoTable(MetadataTableName.MethodDef));
 }

--- a/Reemit.Decompiler.Clr/Metadata/Tables/TypeRefRow.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/TypeRefRow.cs
@@ -1,17 +1,17 @@
 namespace Reemit.Decompiler.Clr.Metadata.Tables;
 
-public class TypeRefRow : IMetadataTableRow
+public class TypeRefRow(CodedIndex resolutionScope, uint typeName, uint typeNamespace)
+    : IMetadataTableRow<TypeRefRow>
 {
     public static MetadataTableName TableName => MetadataTableName.TypeRef;
 
-    public CodedIndex ResolutionScope { get; private set; } = null!;
-    public uint TypeName { get; private set; }
-    public uint TypeNamespace { get; private set; }
+    public CodedIndex ResolutionScope { get; } = resolutionScope;
+    public uint TypeName { get; } = typeName;
+    public uint TypeNamespace { get; } = typeNamespace;
 
-    public void Read(MetadataTableDataReader reader)
-    {
-        ResolutionScope = reader.ReadCodedRid(CodedIndexTagFamily.ResolutionScope);
-        TypeName = reader.ReadStringRid();
-        TypeNamespace = reader.ReadStringRid();
-    }
+    public static TypeRefRow Read(MetadataTableDataReader reader) =>
+        new(
+            reader.ReadCodedRid(CodedIndexTagFamily.ResolutionScope),
+            reader.ReadStringRid(),
+            reader.ReadStringRid());
 }


### PR DESCRIPTION
This PR covers the following task: #2 (Separate metadata tables reading logic from the actual data types)

Marking as draft because I took a slightly different approach than discussed, and you mentioned static interfaces feeling unnatural. I agree with you on that front, but they really feel like the right tool for the job here.

Rather than separating the parser logic from the row types, I opted to refactor `IMetadataTableRow.Read` into a static generic factory method that returns the concrete type. I went with this approach for a couple reasons:

1) Separating the actual parsing from the type sounds good on paper, but in practice I don't think it would work well. What would it look like? A plethora of small readers? One god reader? Given the minimal amount of parsing taking place, it seems overengineered.
2) There's no "clean" way of resolving a reader given only a `IMetadataTableRow` type. Unless I'm overlooking something, we'd need to keep a table of some sort, resort to reflection (searching the assembly for an interface--not exactly futureproof), or similar. Going with the factory approach let's us maintain the original `ReadIfTableIfExists` implementation, which works nicely.

And, of course, this change also has expected benefits: no more `null` suppression, no risk of a partially initialized `IMetadataTableRow`, and `get`-only properties.