### PR TITLE
Add ModuleExplorerTreeView component

### DIFF
--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Tables/TypeDefRowTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Tables/TypeDefRowTests.cs
@@ -22,7 +22,12 @@ public class TypeDefRowTests
         }));
         
         // Assert
-        Assert.Equal(TypeAttributes.Public, row.Flags);
+        Assert.Equal(TypeClassLayoutAttributes.AutoLayout, row.ClassLayout);
+        Assert.Equal(TypeClassSemanticsAttributes.Class, row.ClassSemantics);
+        Assert.Equal((TypeImplementationAttributes)0, row.Implementation);
+        Assert.Equal(TypeStringFormattingAttributes.AnsiClass, row.StringFormatting);
+        Assert.Equal(TypeVisibilityAttributes.Public, row.Visibility);
+        Assert.Equal(1048577u, row.Flags);
         Assert.Equal(1u, row.TypeName);
         Assert.Equal(491u, row.TypeNamespace);
         Assert.Equal(MetadataTableName.TypeRef, row.Extends.ReferencedTable);

--- a/Reemit.Decompiler.Clr/Metadata/CodedIndex.cs
+++ b/Reemit.Decompiler.Clr/Metadata/CodedIndex.cs
@@ -2,6 +2,7 @@ namespace Reemit.Decompiler.Clr.Metadata;
 
 public class CodedIndex
 {
+    public uint ZeroBasedIndex => Rid - 1;
     public uint Rid { get; }
     public MetadataTableName ReferencedTable { get; }
 

--- a/Reemit.Decompiler.Clr/Metadata/FlagMasks.cs
+++ b/Reemit.Decompiler.Clr/Metadata/FlagMasks.cs
@@ -2,6 +2,16 @@ namespace Reemit.Decompiler.Clr.Metadata;
 
 public static class FlagMasks
 {
-    public const uint TypeAttributesMask = 0x7;
+    /// <summary>
+    /// A mask intended for validation of TypeAttributes bitfields.
+    /// </summary>
+    public const uint TypeAttributesMask = 
+        (uint)TypeAttributes.Mask |
+        (uint)TypeClassLayoutAttributes.Mask |
+        (uint)TypeClassSemanticsAttributes.Mask |
+        (uint)TypeImplementationAttributes.Mask |
+        (uint)TypeStringFormattingAttributes.Mask |
+        (uint)TypeVisibilityAttributes.Mask;
+    
     public const uint FieldAccessMask = 0x7;
 }

--- a/Reemit.Decompiler.Clr/Metadata/Tables/IMetadataTableRow.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/IMetadataTableRow.cs
@@ -5,7 +5,7 @@ public interface IMetadataTableRow
     static abstract MetadataTableName TableName { get; }
 }
 
-public interface IMetadataTableRow<T> : IMetadataTableRow
+public interface IMetadataTableRow<out T> : IMetadataTableRow
     where T : IMetadataTableRow<T>
 {
     static abstract T Read(MetadataTableDataReader reader);

--- a/Reemit.Decompiler.Clr/Metadata/Tables/TypeDefRow.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/TypeDefRow.cs
@@ -1,7 +1,7 @@
 namespace Reemit.Decompiler.Clr.Metadata.Tables;
 
 public class TypeDefRow(
-    TypeAttributes flags,
+    uint flags,
     uint typeName,
     uint typeNamespace,
     CodedIndex extends,
@@ -11,19 +11,44 @@ public class TypeDefRow(
 {
     public static MetadataTableName TableName => MetadataTableName.TypeDef;
 
-    public TypeAttributes Flags { get; } = flags;
+    public uint Flags { get; } = flags;
     public uint TypeName { get; } = typeName;
     public uint TypeNamespace { get; } = typeNamespace;
     public CodedIndex Extends { get; } = extends;
     public uint FieldList { get; } = fieldList;
     public uint MethodList { get; } = methodList;
 
-    public static TypeDefRow Read(MetadataTableDataReader reader) =>
-        new(
-            (TypeAttributes)(reader.ReadUInt32() & FlagMasks.TypeAttributesMask),
+    public TypeClassLayoutAttributes ClassLayout =>
+        (TypeClassLayoutAttributes)(Flags & (short)TypeClassLayoutAttributes.Mask);
+    
+    public TypeClassSemanticsAttributes ClassSemantics =>
+        (TypeClassSemanticsAttributes)(Flags & (short)TypeClassSemanticsAttributes.Mask);
+
+    public TypeImplementationAttributes Implementation =>
+        (TypeImplementationAttributes)(Flags & (short)TypeImplementationAttributes.Mask);
+
+    public TypeStringFormattingAttributes StringFormatting =>
+        (TypeStringFormattingAttributes)(Flags & (uint)TypeStringFormattingAttributes.Mask);
+
+    public TypeVisibilityAttributes Visibility =>
+        (TypeVisibilityAttributes)(Flags & (uint)TypeVisibilityAttributes.Mask);
+
+    public static TypeDefRow Read(MetadataTableDataReader reader)
+    {
+        var flags = reader.ReadUInt32();
+        var invalidFlags = flags & ~FlagMasks.TypeAttributesMask;
+        
+        if (invalidFlags != 0x0)
+        {
+            throw new BadImageFormatException("Invalid TypeAttributes flags");
+        }
+
+        return new TypeDefRow(
+            flags,
             reader.ReadStringRid(),
             reader.ReadStringRid(),
             reader.ReadCodedRid(CodedIndexTagFamily.TypeDefOrRef),
             reader.ReadRidIntoTable(MetadataTableName.Field),
             reader.ReadRidIntoTable(MetadataTableName.MethodDef));
+    }
 }

--- a/Reemit.Decompiler.Clr/Metadata/TypeAttributes.cs
+++ b/Reemit.Decompiler.Clr/Metadata/TypeAttributes.cs
@@ -2,7 +2,7 @@ namespace Reemit.Decompiler.Clr.Metadata;
 
 public enum TypeAttributes : uint
 {
-    Abstract = 0x0,
+    Abstract = 0x80,
     Sealed = 0x100,
     SpecialName = 0x400,
     Import = 0x1000,

--- a/Reemit.Decompiler.Clr/Metadata/TypeAttributes.cs
+++ b/Reemit.Decompiler.Clr/Metadata/TypeAttributes.cs
@@ -2,12 +2,24 @@ namespace Reemit.Decompiler.Clr.Metadata;
 
 public enum TypeAttributes : uint
 {
-    NotPublic = 0x0,
-    Public = 0x1,
-    NestedPublic = 0x2,
-    NestedPrivate = 0x3,
-    NestedFamily = 0x4,
-    NestedAssembly = 0x5,
-    NestedFamAndAssem = 0x6,
-    NestedFamOrAssem = 0x7
+    Abstract = 0x0,
+    Sealed = 0x100,
+    SpecialName = 0x400,
+    Import = 0x1000,
+    Serializable = 0x2000,
+    BeforeFieldInit = 0x100000,
+    RTSpecialName = 0x800,
+    HasSecurity = 0x40000,
+    IsTypeForwarder = 0x200000,
+    
+    Mask = 
+        Abstract |
+        Sealed |
+        SpecialName |
+        Import |
+        Serializable |
+        BeforeFieldInit |
+        RTSpecialName |
+        HasSecurity |
+        IsTypeForwarder
 }

--- a/Reemit.Decompiler.Clr/Metadata/TypeClassLayoutAttributes.cs
+++ b/Reemit.Decompiler.Clr/Metadata/TypeClassLayoutAttributes.cs
@@ -1,0 +1,16 @@
+namespace Reemit.Decompiler.Clr.Metadata;
+
+/// <summary>
+/// Based on II.23.1.15 Flags for types [TypeAttributes] 
+/// </summary>
+public enum TypeClassLayoutAttributes : uint
+{
+    AutoLayout = 0x0,
+    SequentialLayout = 0x8,
+    ExplicitLayout = 0x10,
+    
+    Mask = 
+        AutoLayout |
+        SequentialLayout |
+        ExplicitLayout
+}

--- a/Reemit.Decompiler.Clr/Metadata/TypeClassSemanticsAttributes.cs
+++ b/Reemit.Decompiler.Clr/Metadata/TypeClassSemanticsAttributes.cs
@@ -1,0 +1,14 @@
+namespace Reemit.Decompiler.Clr.Metadata;
+
+/// <summary>
+/// Based on II.23.1.15 Flags for types [TypeAttributes] 
+/// </summary>
+public enum TypeClassSemanticsAttributes : ushort
+{
+    Class = 0x0,
+    Interface = 0x20,
+    
+    Mask =
+        Class |
+        Interface
+}

--- a/Reemit.Decompiler.Clr/Metadata/TypeImplementationAttributes.cs
+++ b/Reemit.Decompiler.Clr/Metadata/TypeImplementationAttributes.cs
@@ -1,0 +1,14 @@
+namespace Reemit.Decompiler.Clr.Metadata;
+
+/// <summary>
+/// Based on II.23.1.15 Flags for types [TypeAttributes] 
+/// </summary>
+public enum TypeImplementationAttributes : ushort
+{
+    Import = 0x1000,
+    Serializable = 0x2000,
+    
+    Mask = 
+        Import |
+        Serializable
+}

--- a/Reemit.Decompiler.Clr/Metadata/TypeStringFormattingAttributes.cs
+++ b/Reemit.Decompiler.Clr/Metadata/TypeStringFormattingAttributes.cs
@@ -1,0 +1,23 @@
+namespace Reemit.Decompiler.Clr.Metadata;
+
+/// <summary>
+/// Based on II.23.1.15 Flags for types [TypeAttributes] 
+/// </summary>
+public enum TypeStringFormattingAttributes : uint
+{
+    AnsiClass = 0x0,
+    UnicodeClass = 0x10000,
+    AutoClass = 0x20000,
+    CustomFormatClass = 0x30000,
+
+    /// <summary>
+    /// A mask to retrieve non-standard encoding information for native interop.
+    /// </summary>
+    CustomStringFormatMask = 0xC00000,
+
+    Mask =
+        AnsiClass |
+        UnicodeClass |
+        AutoClass |
+        CustomFormatClass
+}

--- a/Reemit.Decompiler.Clr/Metadata/TypeVisibilityAttributes.cs
+++ b/Reemit.Decompiler.Clr/Metadata/TypeVisibilityAttributes.cs
@@ -1,0 +1,26 @@
+namespace Reemit.Decompiler.Clr.Metadata;
+
+/// <summary>
+/// Based on II.23.1.15 Flags for types [TypeAttributes] 
+/// </summary>
+public enum TypeVisibilityAttributes : ushort
+{
+    NotPublic = 0x0,
+    Public = 0x1,
+    NestedPublic = 0x2,
+    NestedPrivate = 0x3,
+    NestedFamily = 0x4,
+    NestedAssembly = 0x5,
+    NestedFamAndAssem = 0x6,
+    NestedFamOrAssem = 0x7,
+    
+    Mask =
+        NotPublic |
+        Public |
+        NestedPublic |
+        NestedPrivate |
+        NestedFamily |
+        NestedAssembly |
+        NestedFamAndAssem |
+        NestedFamOrAssem
+}

--- a/Reemit.Decompiler/ClrModule.cs
+++ b/Reemit.Decompiler/ClrModule.cs
@@ -7,12 +7,18 @@ namespace Reemit.Decompiler;
 public class ClrModule
 {
     public string Name { get; }
-    public IReadOnlyList<ClrType>? Types { get; }
+    public IReadOnlyList<ClrType> Types { get; }
+    public IReadOnlyList<ClrNamespace> Namespaces { get; }
 
     private ClrModule(string name, IReadOnlyList<ClrType>? types)
     {
         Name = name;
-        Types = types;
+        Types = types ?? [];
+        Namespaces = Types
+            .GroupBy(t => t.Namespace)
+            .Select(g => new ClrNamespace(g.Key, g.ToArray().AsReadOnly()))
+            .ToArray()
+            .AsReadOnly();
     }
 
     public static ClrModule Open(string fileName)
@@ -50,7 +56,4 @@ public class ClrModule
 
         return new ClrModule(name, types);
     }
-
-    public string DebugDump() =>
-        $"Module: {Name}, Types: {string.Join(", ", Types?.Select(x => x.Name) ?? Array.Empty<string>())}";
 }

--- a/Reemit.Decompiler/ClrNamespace.cs
+++ b/Reemit.Decompiler/ClrNamespace.cs
@@ -1,0 +1,8 @@
+namespace Reemit.Decompiler;
+
+public class ClrNamespace(string name, IReadOnlyList<ClrType> children)
+{
+    public string Name => name;
+
+    public IReadOnlyList<ClrType> Children => children;
+}

--- a/Reemit.Decompiler/ClrType.cs
+++ b/Reemit.Decompiler/ClrType.cs
@@ -1,15 +1,21 @@
+using Reemit.Decompiler.Clr.Metadata;
 using Reemit.Decompiler.Clr.Metadata.Tables;
 
 namespace Reemit.Decompiler;
 
-public class ClrType(string name, string @namespace)
+public class ClrType(bool isInterface, string name, string @namespace)
 {
-    public string Name { get; } = name;
-    public string Namespace { get; } = @namespace;
+    public bool IsInterface => isInterface;
+    public string Name => name;
+    public string Namespace => @namespace;
 
     public static ClrType FromTypeDefRow(TypeDefRow typeDefRow, ClrMetadataContext context)
     {
         var stringsHeap = context.StringsHeapStream;
-        return new ClrType(stringsHeap.Read(typeDefRow.TypeName), stringsHeap.Read(typeDefRow.TypeNamespace));
+        // TODO: Check if also derives ultimately from System.Object
+        var isInterface = typeDefRow.ClassSemantics == TypeClassSemanticsAttributes.Interface;
+        var type = new ClrType(isInterface,
+            stringsHeap.Read(typeDefRow.TypeName), stringsHeap.Read(typeDefRow.TypeNamespace));
+        return type;
     }
 }

--- a/Reemit.Decompiler/ClrType.cs
+++ b/Reemit.Decompiler/ClrType.cs
@@ -31,7 +31,8 @@ public class ClrType(bool isInterface, bool isValueType, string name, string @na
         // TODO: This should be replaced with something better as soon as we have the aforementioned tables implemented. 
         if (typeDefRow.Extends.ReferencedTable == MetadataTableName.TypeRef)
         {
-            var extendsRow = context.MetadataTablesStream.TypeRef?.Rows[(int)typeDefRow.Extends.ZeroBasedIndex];
+            var extendsRow =
+                context.MetadataTablesStream.TypeRef?.Rows.ElementAtOrDefault((int)typeDefRow.Extends.ZeroBasedIndex);
 
             if (extendsRow is not null)
             {

--- a/Reemit.Decompiler/ClrType.cs
+++ b/Reemit.Decompiler/ClrType.cs
@@ -3,8 +3,9 @@ using Reemit.Decompiler.Clr.Metadata.Tables;
 
 namespace Reemit.Decompiler;
 
-public class ClrType(bool isInterface, string name, string @namespace)
+public class ClrType(bool isInterface, bool isValueType, string name, string @namespace)
 {
+    public bool IsValueType => isValueType;
     public bool IsInterface => isInterface;
     public string Name => name;
     public string Namespace => @namespace;
@@ -14,7 +15,33 @@ public class ClrType(bool isInterface, string name, string @namespace)
         var stringsHeap = context.StringsHeapStream;
         // TODO: Check if also derives ultimately from System.Object
         var isInterface = typeDefRow.ClassSemantics == TypeClassSemanticsAttributes.Interface;
-        var type = new ClrType(isInterface,
+        var isValueType = false;
+
+        /*
+         * From ECMA-335 II.22.37:
+         * Note that any type shall be one, and only one, of
+           - Class (Flags.Interface = 0, and derives ultimately from System.Object)
+           - Interface (Flags.Interface = 1)
+           - Value type, derived ultimately from System.ValueType
+         */
+        // HACK: Check if the type extends System.ValueType to tell if it's a value type.
+        // Currently, we are not able to properly resolve the Extends CodedIndex as we are still lacking
+        // implementation of some tables it can reference. So, for that reason, this hack below was implemented.
+        // It only takes the Extends RID into consideration if it references TypeRef table.
+        // TODO: This should be replaced with something better as soon as we have the aforementioned tables implemented. 
+        if (typeDefRow.Extends.ReferencedTable == MetadataTableName.TypeRef)
+        {
+            var extendsRow = context.MetadataTablesStream.TypeRef?.Rows[(int)typeDefRow.Extends.ZeroBasedIndex];
+
+            if (extendsRow is not null)
+            {
+                var extendsTypeName = stringsHeap.Read(extendsRow.TypeName);
+                var extendsTypeNamespace = stringsHeap.Read(extendsRow.TypeNamespace);
+                isValueType = $"{extendsTypeNamespace}.{extendsTypeName}" == "System.ValueType";
+            }
+        }
+
+        var type = new ClrType(isInterface, isValueType,
             stringsHeap.Read(typeDefRow.TypeName), stringsHeap.Read(typeDefRow.TypeNamespace));
         return type;
     }

--- a/Reemit.Gui/Models/IconKind.cs
+++ b/Reemit.Gui/Models/IconKind.cs
@@ -1,0 +1,10 @@
+namespace Reemit.Gui.Models;
+
+public enum IconKind
+{
+    Class,
+    Interface,
+    Module,
+    Namespace,
+    Structure
+}

--- a/Reemit.Gui/Reemit.Gui.csproj
+++ b/Reemit.Gui/Reemit.Gui.csproj
@@ -9,7 +9,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Folder Include="Models\"/>
         <AvaloniaResource Include="Assets\**"/>
     </ItemGroup>
 

--- a/Reemit.Gui/ViewModels/Controls/ModuleExplorer/IModuleExplorerNodeViewModel.cs
+++ b/Reemit.Gui/ViewModels/Controls/ModuleExplorer/IModuleExplorerNodeViewModel.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace Reemit.Gui.ViewModels.Controls.ModuleExplorer;
+
+public interface IModuleExplorerNodeViewModel
+{
+    IReadOnlyList<IModuleExplorerNodeViewModel> Children { get; }
+}

--- a/Reemit.Gui/ViewModels/Controls/ModuleExplorer/ModuleExplorerClassNodeViewModel.cs
+++ b/Reemit.Gui/ViewModels/Controls/ModuleExplorer/ModuleExplorerClassNodeViewModel.cs
@@ -1,0 +1,5 @@
+using Reemit.Decompiler;
+
+namespace Reemit.Gui.ViewModels.Controls.ModuleExplorer;
+
+public class ModuleExplorerClassNodeViewModel(ClrType clrType) : ModuleExplorerTypeNodeViewModel(clrType);

--- a/Reemit.Gui/ViewModels/Controls/ModuleExplorer/ModuleExplorerInterfaceNodeViewModel.cs
+++ b/Reemit.Gui/ViewModels/Controls/ModuleExplorer/ModuleExplorerInterfaceNodeViewModel.cs
@@ -1,0 +1,5 @@
+using Reemit.Decompiler;
+
+namespace Reemit.Gui.ViewModels.Controls.ModuleExplorer;
+
+public class ModuleExplorerInterfaceNodeViewModel(ClrType type) : ModuleExplorerTypeNodeViewModel(type);

--- a/Reemit.Gui/ViewModels/Controls/ModuleExplorer/ModuleExplorerModuleNodeViewModel.cs
+++ b/Reemit.Gui/ViewModels/Controls/ModuleExplorer/ModuleExplorerModuleNodeViewModel.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.Linq;
+using Reemit.Decompiler;
+
+namespace Reemit.Gui.ViewModels.Controls.ModuleExplorer;
+
+public class ModuleExplorerModuleNodeViewModel(ClrModule clrModule) : IModuleExplorerNodeViewModel
+{
+    public string Name => clrModule.Name;
+
+    public IReadOnlyList<IModuleExplorerNodeViewModel> Children =>
+        clrModule.Namespaces.Select(x => new ModuleExplorerNamespaceNodeViewModel(x)).ToArray().AsReadOnly();
+}

--- a/Reemit.Gui/ViewModels/Controls/ModuleExplorer/ModuleExplorerNamespaceNodeViewModel.cs
+++ b/Reemit.Gui/ViewModels/Controls/ModuleExplorer/ModuleExplorerNamespaceNodeViewModel.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.Linq;
+using Reemit.Decompiler;
+
+namespace Reemit.Gui.ViewModels.Controls.ModuleExplorer;
+
+public class ModuleExplorerNamespaceNodeViewModel(ClrNamespace clrNamespace) : IModuleExplorerNodeViewModel
+{
+    public string Name => clrNamespace.Name;
+
+    public IReadOnlyList<IModuleExplorerNodeViewModel> Children => clrNamespace.Children
+        .Select(x => (IModuleExplorerNodeViewModel)(x.IsInterface ? new ModuleExplorerInterfaceNodeViewModel(x) : new ModuleExplorerClassNodeViewModel(x)))
+        .ToArray()
+        .AsReadOnly();
+}

--- a/Reemit.Gui/ViewModels/Controls/ModuleExplorer/ModuleExplorerNamespaceNodeViewModel.cs
+++ b/Reemit.Gui/ViewModels/Controls/ModuleExplorer/ModuleExplorerNamespaceNodeViewModel.cs
@@ -9,7 +9,14 @@ public class ModuleExplorerNamespaceNodeViewModel(ClrNamespace clrNamespace) : I
     public string Name => clrNamespace.Name;
 
     public IReadOnlyList<IModuleExplorerNodeViewModel> Children => clrNamespace.Children
-        .Select(x => (IModuleExplorerNodeViewModel)(x.IsInterface ? new ModuleExplorerInterfaceNodeViewModel(x) : new ModuleExplorerClassNodeViewModel(x)))
+        .Select(x => (IModuleExplorerNodeViewModel)
+            (x switch
+            {
+                { IsInterface: true } => new ModuleExplorerInterfaceNodeViewModel(x),
+                { IsValueType: true } => new ModuleExplorerStructNodeViewModel(x),
+                _ => new ModuleExplorerClassNodeViewModel(x)
+            })
+        )
         .ToArray()
         .AsReadOnly();
 }

--- a/Reemit.Gui/ViewModels/Controls/ModuleExplorer/ModuleExplorerStructNodeViewModel.cs
+++ b/Reemit.Gui/ViewModels/Controls/ModuleExplorer/ModuleExplorerStructNodeViewModel.cs
@@ -1,0 +1,5 @@
+using Reemit.Decompiler;
+
+namespace Reemit.Gui.ViewModels.Controls.ModuleExplorer;
+
+public class ModuleExplorerStructNodeViewModel(ClrType clrType) : ModuleExplorerTypeNodeViewModel(clrType);

--- a/Reemit.Gui/ViewModels/Controls/ModuleExplorer/ModuleExplorerTreeViewModel.cs
+++ b/Reemit.Gui/ViewModels/Controls/ModuleExplorer/ModuleExplorerTreeViewModel.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.ObjectModel;
+using DynamicData;
+using DynamicData.Alias;
+using DynamicData.Binding;
+using Reemit.Decompiler;
+
+namespace Reemit.Gui.ViewModels.Controls.ModuleExplorer;
+
+public class ModuleExplorerTreeViewModel
+{
+    public ReadOnlyObservableCollection<ModuleExplorerModuleNodeViewModel> RootNodes => _rootNodes;
+    private readonly ReadOnlyObservableCollection<ModuleExplorerModuleNodeViewModel> _rootNodes;
+
+    public ModuleExplorerTreeViewModel(ReadOnlyObservableCollection<ClrModule> clrModules)
+    {
+        clrModules.ToObservableChangeSet()
+            .Select(x => new ModuleExplorerModuleNodeViewModel(x))
+            .Bind(out _rootNodes)
+            .Subscribe();
+    }
+}

--- a/Reemit.Gui/ViewModels/Controls/ModuleExplorer/ModuleExplorerTypeNodeViewModel.cs
+++ b/Reemit.Gui/ViewModels/Controls/ModuleExplorer/ModuleExplorerTypeNodeViewModel.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using Reemit.Decompiler;
+
+namespace Reemit.Gui.ViewModels.Controls.ModuleExplorer;
+
+public class ModuleExplorerTypeNodeViewModel(ClrType type) : IModuleExplorerNodeViewModel
+{
+    public string Name => type.Name;
+
+    public IReadOnlyList<IModuleExplorerNodeViewModel> Children => [];
+}

--- a/Reemit.Gui/ViewModels/HomeViewModel.cs
+++ b/Reemit.Gui/ViewModels/HomeViewModel.cs
@@ -1,17 +1,31 @@
+using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using DynamicData;
 using ReactiveUI;
 using Reemit.Decompiler;
+using Reemit.Gui.ViewModels.Controls.ModuleExplorer;
 
 namespace Reemit.Gui.ViewModels;
 
 public class HomeViewModel : ReactiveObject, IRoutableViewModel
 {
-    public IReadOnlyList<ClrModule> Modules { get; }
+    private readonly ReadOnlyObservableCollection<ClrModule> _modules;
+    
+    public ModuleExplorerTreeViewModel ModuleExplorerTreeViewModel { get; }
+
+    private readonly SourceList<ClrModule> _modulesSource;
 
     public HomeViewModel(IScreen hostScreen, IReadOnlyList<ClrModule> modules)
     {
-        Modules = modules;
+        _modulesSource = new SourceList<ClrModule>();
+        _modulesSource.AddRange(modules);
+        _modulesSource.Connect()
+            .Bind(out _modules)
+            .Subscribe();
+
         HostScreen = hostScreen;
+        ModuleExplorerTreeViewModel = new ModuleExplorerTreeViewModel(_modules);
     }
 
     public string UrlPathSegment => nameof(HomeViewModel);

--- a/Reemit.Gui/Views/Controls/Icons/ClassIcon.axaml
+++ b/Reemit.Gui/Views/Controls/Icons/ClassIcon.axaml
@@ -1,0 +1,31 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="Reemit.Gui.Views.Controls.Icons.ClassIcon">
+    <Viewbox Width="16 " Height="16">
+        <Rectangle Width="16 " Height="16">
+            <Rectangle.Resources>
+                <SolidColorBrush x:Key="canvas" Opacity="0" />
+                <SolidColorBrush x:Key="light-yellow-10" Color="#996f00" Opacity="0.1" />
+                <SolidColorBrush x:Key="light-yellow" Color="#996f00" Opacity="1" />
+            </Rectangle.Resources>
+            <Rectangle.Fill>
+                <DrawingBrush Stretch="None">
+                    <DrawingBrush.Drawing>
+                        <DrawingGroup>
+                            <DrawingGroup>
+                                <GeometryDrawing Brush="{DynamicResource canvas}" Geometry="F1M16,16H0V0H16Z" />
+                            </DrawingGroup>
+                            <DrawingGroup>
+                                <GeometryDrawing Brush="{DynamicResource light-yellow-10}" Geometry="F1M5.5.5l3,3-5,5-3-3Zm10,6-2-2-3,3,2,2Zm-5,7,2,2,3-3-2-2Z" />
+                                <GeometryDrawing Brush="{DynamicResource light-yellow}" Geometry="F1M10.146,7.854l2,2h.708l3-3V6.146l-2-2h-.708L11.293,6H6.707L8.854,3.854V3.146l-3-3H5.146l-5,5v.708l3,3h.708L5.707,7H8v5.5l.5.5h1.793l-.147.146v.708l2,2h.708l3-3v-.708l-2-2h-.708L11.293,12H9V7h1.293l-.147.146ZM3.5,7.793,1.207,5.5,5.5,1.207,7.793,3.5Zm10,3.414L14.793,12.5,12.5,14.793,11.207,13.5Zm0-6L14.793,6.5,12.5,8.793,11.207,7.5Z" />
+                            </DrawingGroup>
+                        </DrawingGroup>
+                    </DrawingBrush.Drawing>
+                </DrawingBrush>
+            </Rectangle.Fill>
+        </Rectangle>
+    </Viewbox>
+</UserControl>

--- a/Reemit.Gui/Views/Controls/Icons/ClassIcon.axaml.cs
+++ b/Reemit.Gui/Views/Controls/Icons/ClassIcon.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Reemit.Gui.Views.Controls.Icons;
+
+public partial class ClassIcon : UserControl
+{
+    public ClassIcon()
+    {
+        InitializeComponent();
+    }
+}

--- a/Reemit.Gui/Views/Controls/Icons/Icon.axaml
+++ b/Reemit.Gui/Views/Controls/Icons/Icon.axaml
@@ -1,0 +1,6 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="Reemit.Gui.Views.Controls.Icons.Icon" />

--- a/Reemit.Gui/Views/Controls/Icons/Icon.axaml.cs
+++ b/Reemit.Gui/Views/Controls/Icons/Icon.axaml.cs
@@ -1,3 +1,4 @@
+using System;
 using Avalonia;
 using Avalonia.Controls;
 using Reemit.Gui.Models;
@@ -44,7 +45,8 @@ public partial class Icon : Panel
             IconKind.Interface => new InterfaceIcon(),
             IconKind.Module => new ModuleIcon(),
             IconKind.Namespace => new NamespaceIcon(),
-            IconKind.Structure => new StructureIcon()
+            IconKind.Structure => new StructureIcon(),
+            _ => throw new ArgumentOutOfRangeException(nameof(Kind), Kind, "Unrecognized icon kind")
         });
             
         Children.Clear();

--- a/Reemit.Gui/Views/Controls/Icons/Icon.axaml.cs
+++ b/Reemit.Gui/Views/Controls/Icons/Icon.axaml.cs
@@ -1,0 +1,53 @@
+using Avalonia;
+using Avalonia.Controls;
+using Reemit.Gui.Models;
+
+namespace Reemit.Gui.Views.Controls.Icons;
+
+public partial class Icon : Panel
+{
+    public static readonly DirectProperty<Icon, IconKind> KindProperty =
+        AvaloniaProperty.RegisterDirect<Icon, IconKind>(
+            nameof(Kind),
+            o => o.Kind,
+            (o, v) => o.Kind = v);
+
+    private IconKind _kind = IconKind.Class;
+
+    public IconKind Kind
+    {
+        get => _kind;
+        set => SetAndRaise(KindProperty, ref _kind, value);
+    }
+    
+    public Icon()
+    {
+        InitializeComponent();
+        UpdateIcon();
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        if (change.Property == KindProperty)
+        {
+            UpdateIcon();
+        }
+
+        base.OnPropertyChanged(change);
+    }
+
+    private void UpdateIcon()
+    {
+        var icon = (Control)(Kind switch
+        {
+            IconKind.Class => new ClassIcon(),
+            IconKind.Interface => new InterfaceIcon(),
+            IconKind.Module => new ModuleIcon(),
+            IconKind.Namespace => new NamespaceIcon(),
+            IconKind.Structure => new StructureIcon()
+        });
+            
+        Children.Clear();
+        Children.Add(icon);
+    }
+}

--- a/Reemit.Gui/Views/Controls/Icons/InterfaceIcon.axaml
+++ b/Reemit.Gui/Views/Controls/Icons/InterfaceIcon.axaml
@@ -1,0 +1,36 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:system="clr-namespace:System;assembly=System.Runtime"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="Reemit.Gui.Views.Controls.Icons.InterfaceIcon">
+    <Viewbox Width="16 " Height="16">
+        <Rectangle Width="16 " Height="16">
+            <Rectangle.Resources>
+                <SolidColorBrush x:Key="canvas" Opacity="0" />
+                <SolidColorBrush x:Key="light-blue" Color="#005dba" Opacity="1" />
+                <SolidColorBrush x:Key="light-blue-10" Color="#005dba" Opacity="0.1" />
+                <system:Double x:Key="cls-1">0.75</system:Double>
+            </Rectangle.Resources>
+            <Rectangle.Fill>
+                <DrawingBrush Stretch="None">
+                    <DrawingBrush.Drawing>
+                        <DrawingGroup>
+                            <DrawingGroup>
+                                <GeometryDrawing Brush="{DynamicResource canvas}" Geometry="F1M16,16H0V0H16Z" />
+                            </DrawingGroup>
+                            <DrawingGroup>
+                                <DrawingGroup Opacity="{DynamicResource cls-1}">
+                                    <GeometryDrawing Brush="{DynamicResource light-blue}" Geometry="F1M8.5,7V8h-4V7Z" />
+                                </DrawingGroup>
+                                <GeometryDrawing Brush="{DynamicResource light-blue-10}" Geometry="F1M4.5,7.5a2,2,0,1,1-2-2A2,2,0,0,1,4.5,7.5Zm10,0a3,3,0,1,1-3-3A3,3,0,0,1,14.5,7.5Z" />
+                                <GeometryDrawing Brush="{DynamicResource light-blue}" Geometry="F1M2.5,5A2.5,2.5,0,1,0,5,7.5,2.5,2.5,0,0,0,2.5,5Zm0,4A1.5,1.5,0,1,1,4,7.5,1.5,1.5,0,0,1,2.5,9Zm9-5A3.5,3.5,0,1,0,15,7.5,3.5,3.5,0,0,0,11.5,4Zm0,6A2.5,2.5,0,1,1,14,7.5,2.5,2.5,0,0,1,11.5,10Z" />
+                            </DrawingGroup>
+                        </DrawingGroup>
+                    </DrawingBrush.Drawing>
+                </DrawingBrush>
+            </Rectangle.Fill>
+        </Rectangle>
+    </Viewbox>
+</UserControl>

--- a/Reemit.Gui/Views/Controls/Icons/InterfaceIcon.axaml.cs
+++ b/Reemit.Gui/Views/Controls/Icons/InterfaceIcon.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Reemit.Gui.Views.Controls.Icons;
+
+public partial class InterfaceIcon : UserControl
+{
+    public InterfaceIcon()
+    {
+        InitializeComponent();
+    }
+}

--- a/Reemit.Gui/Views/Controls/Icons/ModuleIcon.axaml
+++ b/Reemit.Gui/Views/Controls/Icons/ModuleIcon.axaml
@@ -1,0 +1,37 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:system="clr-namespace:System;assembly=System.Runtime"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="Reemit.Gui.Views.Controls.Icons.ModuleIcon">
+    <Viewbox Width="16" Height="16">
+        <Rectangle Width="16" Height="16">
+            <Rectangle.Resources>
+                <SolidColorBrush x:Key="canvas" Opacity="0" />
+                <SolidColorBrush x:Key="light-purple-10" Color="#6936aa" Opacity="0.1" />
+                <SolidColorBrush x:Key="light-purple" Color="#6936aa" Opacity="1" />
+                <system:Double x:Key="cls-1">0.75</system:Double>
+            </Rectangle.Resources>
+            <Rectangle.Fill>
+                <DrawingBrush Stretch="None">
+                    <DrawingBrush.Drawing>
+                        <DrawingGroup>
+                            <DrawingGroup>
+                                <GeometryDrawing Brush="{DynamicResource canvas}" Geometry="F1M16,16H0V0H16Z" />
+                            </DrawingGroup>
+                            <DrawingGroup>
+                                <DrawingGroup Opacity="{DynamicResource cls-1}">
+                                    <GeometryDrawing Brush="{DynamicResource light-purple-10}" Geometry="F1M2.5,9.5v5h12v-5Z" />
+                                    <GeometryDrawing Brush="{DynamicResource light-purple}" Geometry="F1M14.5,9H2.5L2,9.5v5l.5.5h12l.5-.5v-5ZM14,14H3V10H14Z" />
+                                </DrawingGroup>
+                                <GeometryDrawing Brush="{DynamicResource light-purple-10}" Geometry="F1M14.5,2.5v5h-5v-5Zm-12,5h5v-5h-5Z" />
+                                <GeometryDrawing Brush="{DynamicResource light-purple}" Geometry="F1M14.5,2h-5L9,2.5v5l.5.5h5l.5-.5v-5ZM14,7H10V3h4ZM2.5,2,2,2.5v5l.5.5h5L8,7.5v-5L7.5,2ZM7,7H3V3H7Z" />
+                            </DrawingGroup>
+                        </DrawingGroup>
+                    </DrawingBrush.Drawing>
+                </DrawingBrush>
+            </Rectangle.Fill>
+        </Rectangle>
+    </Viewbox>
+</UserControl>

--- a/Reemit.Gui/Views/Controls/Icons/ModuleIcon.axaml.cs
+++ b/Reemit.Gui/Views/Controls/Icons/ModuleIcon.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Reemit.Gui.Views.Controls.Icons;
+
+public partial class ModuleIcon : UserControl
+{
+    public ModuleIcon()
+    {
+        InitializeComponent();
+    }
+}

--- a/Reemit.Gui/Views/Controls/Icons/NamespaceIcon.axaml
+++ b/Reemit.Gui/Views/Controls/Icons/NamespaceIcon.axaml
@@ -1,0 +1,29 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="Reemit.Gui.Views.Controls.Icons.NamespaceIcon">
+    <Viewbox Width="16 " Height="16">
+        <Rectangle Width="16 " Height="16">
+            <Rectangle.Resources>
+                <SolidColorBrush x:Key="canvas" Opacity="0" />
+                <SolidColorBrush x:Key="light-defaultgrey" Color="#212121" Opacity="1" />
+            </Rectangle.Resources>
+            <Rectangle.Fill>
+                <DrawingBrush Stretch="None">
+                    <DrawingBrush.Drawing>
+                        <DrawingGroup>
+                            <DrawingGroup>
+                                <GeometryDrawing Brush="{DynamicResource canvas}" Geometry="F1M16,16H0V0H16Z" />
+                            </DrawingGroup>
+                            <DrawingGroup>
+                                <GeometryDrawing Brush="{DynamicResource light-defaultgrey}" Geometry="F1M4.9,2,5,2v.9l-.092,0a.94.94,0,0,0-.745.332,1.784,1.784,0,0,0-.229,1.025V6.23a1.741,1.741,0,0,1-.888,1.786c.57.2.888.819.888,1.8v1.89a3.406,3.406,0,0,0,.053.646,1.071,1.071,0,0,0,.164.417.7.7,0,0,0,.29.24A1.246,1.246,0,0,0,4.9,13.1l.1,0V14l-.1,0a2.079,2.079,0,0,1-1.478-.538,2.187,2.187,0,0,1-.5-1.577v-2a1.948,1.948,0,0,0-.249-1.079A.914.914,0,0,0,1.963,8.4L1.875,8.39V7.61L1.962,7.6c.645-.07.959-.541.959-1.438V4.132a2.206,2.206,0,0,1,.5-1.586A2.062,2.062,0,0,1,4.9,2ZM14.03,7.6c-.64-.063-.951-.533-.951-1.438V4.132a2.2,2.2,0,0,0-.5-1.591A2.069,2.069,0,0,0,11.1,2L11,2v.9l.093,0A1.357,1.357,0,0,1,11.531,3a.693.693,0,0,1,.29.218A1.174,1.174,0,0,1,12,3.622a2.779,2.779,0,0,1,.064.644V6.23c0,.95.319,1.559.892,1.754a1.8,1.8,0,0,0-.892,1.833v1.89a3.181,3.181,0,0,1-.061.675,1.07,1.07,0,0,1-.178.416.671.671,0,0,1-.29.219,1.291,1.291,0,0,1-.442.081l-.1,0V14l.1,0a2.069,2.069,0,0,0,1.477-.538,2.184,2.184,0,0,0,.5-1.577v-2c0-.929.311-1.415.952-1.485l.087-.009V7.609Z" />
+                            </DrawingGroup>
+                        </DrawingGroup>
+                    </DrawingBrush.Drawing>
+                </DrawingBrush>
+            </Rectangle.Fill>
+        </Rectangle>
+    </Viewbox>
+</UserControl>

--- a/Reemit.Gui/Views/Controls/Icons/NamespaceIcon.axaml.cs
+++ b/Reemit.Gui/Views/Controls/Icons/NamespaceIcon.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Reemit.Gui.Views.Controls.Icons;
+
+public partial class NamespaceIcon : UserControl
+{
+    public NamespaceIcon()
+    {
+        InitializeComponent();
+    }
+}

--- a/Reemit.Gui/Views/Controls/Icons/StructureIcon.axaml
+++ b/Reemit.Gui/Views/Controls/Icons/StructureIcon.axaml
@@ -1,0 +1,37 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:system="clr-namespace:System;assembly=System.Runtime"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="Reemit.Gui.Views.Controls.Icons.StructureIcon">
+    <Viewbox Width="16 " Height="16">
+        <Rectangle Width="16 " Height="16">
+            <Rectangle.Resources>
+                <SolidColorBrush x:Key="canvas" Opacity="0" />
+                <SolidColorBrush x:Key="light-blue-10" Color="#005dba" Opacity="0.1" />
+                <SolidColorBrush x:Key="light-blue" Color="#005dba" Opacity="1" />
+                <system:Double x:Key="cls-1">0.75</system:Double>
+            </Rectangle.Resources>
+            <Rectangle.Fill>
+                <DrawingBrush Stretch="None">
+                    <DrawingBrush.Drawing>
+                        <DrawingGroup>
+                            <DrawingGroup>
+                                <GeometryDrawing Brush="{DynamicResource canvas}" Geometry="F1M16,16H0V0H16Z" />
+                            </DrawingGroup>
+                            <DrawingGroup>
+                                <DrawingGroup Opacity="{DynamicResource cls-1}">
+                                    <GeometryDrawing Brush="{DynamicResource light-blue-10}" Geometry="F1M4.5,9.5v3h-3v-3Zm10,0v3h-3v-3Z" />
+                                    <GeometryDrawing Brush="{DynamicResource light-blue}" Geometry="F1M14.5,9h-3l-.5.5v3l.5.5h3l.5-.5v-3ZM14,12H12V10h2ZM1.5,9,1,9.5v3l.5.5h3l.5-.5v-3L4.5,9ZM4,12H2V10H4Z" />
+                                </DrawingGroup>
+                                <GeometryDrawing Brush="{DynamicResource light-blue-10}" Geometry="F1M14.5,4.5v3H1.5v-3Z" />
+                                <GeometryDrawing Brush="{DynamicResource light-blue}" Geometry="F1M14.5,4H1.5L1,4.5v3l.5.5h13l.5-.5v-3ZM14,7H2V5H14Z" />
+                            </DrawingGroup>
+                        </DrawingGroup>
+                    </DrawingBrush.Drawing>
+                </DrawingBrush>
+            </Rectangle.Fill>
+        </Rectangle>
+    </Viewbox>
+</UserControl>

--- a/Reemit.Gui/Views/Controls/Icons/StructureIcon.axaml.cs
+++ b/Reemit.Gui/Views/Controls/Icons/StructureIcon.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Reemit.Gui.Views.Controls.Icons;
+
+public partial class StructureIcon : UserControl
+{
+    public StructureIcon()
+    {
+        InitializeComponent();
+    }
+}

--- a/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerClassNodeView.axaml
+++ b/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerClassNodeView.axaml
@@ -1,0 +1,16 @@
+<rxui:ReactiveUserControl x:TypeArguments="moduleExplorerVM:ModuleExplorerClassNodeViewModel" xmlns="https://github.com/avaloniaui"
+                                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                                xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                                xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                                xmlns:icons="clr-namespace:Reemit.Gui.Views.Controls.Icons"
+                                xmlns:moduleExplorer="clr-namespace:Reemit.Gui.Views.Controls.ModuleExplorer"
+                                xmlns:rxui="http://reactiveui.net"
+                                xmlns:moduleExplorerVM="clr-namespace:Reemit.Gui.ViewModels.Controls.ModuleExplorer"
+                                mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+                                x:Class="Reemit.Gui.Views.Controls.ModuleExplorer.ModuleExplorerClassNodeView">
+    <moduleExplorer:ModuleExplorerNodeView Name="NodeView">
+        <moduleExplorer:ModuleExplorerNodeView.Icon>
+            <icons:ClassIcon />
+        </moduleExplorer:ModuleExplorerNodeView.Icon>
+    </moduleExplorer:ModuleExplorerNodeView>
+</rxui:ReactiveUserControl>

--- a/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerClassNodeView.axaml
+++ b/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerClassNodeView.axaml
@@ -1,16 +1,12 @@
-<rxui:ReactiveUserControl x:TypeArguments="moduleExplorerVM:ModuleExplorerClassNodeViewModel" xmlns="https://github.com/avaloniaui"
-                                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                                xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                                xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                                xmlns:icons="clr-namespace:Reemit.Gui.Views.Controls.Icons"
-                                xmlns:moduleExplorer="clr-namespace:Reemit.Gui.Views.Controls.ModuleExplorer"
-                                xmlns:rxui="http://reactiveui.net"
-                                xmlns:moduleExplorerVM="clr-namespace:Reemit.Gui.ViewModels.Controls.ModuleExplorer"
-                                mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
-                                x:Class="Reemit.Gui.Views.Controls.ModuleExplorer.ModuleExplorerClassNodeView">
-    <moduleExplorer:ModuleExplorerNodeView Name="NodeView">
-        <moduleExplorer:ModuleExplorerNodeView.Icon>
-            <icons:ClassIcon />
-        </moduleExplorer:ModuleExplorerNodeView.Icon>
-    </moduleExplorer:ModuleExplorerNodeView>
+<rxui:ReactiveUserControl x:TypeArguments="moduleExplorerVM:ModuleExplorerClassNodeViewModel"
+                          xmlns="https://github.com/avaloniaui"
+                          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                          xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                          xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                          xmlns:moduleExplorer="clr-namespace:Reemit.Gui.Views.Controls.ModuleExplorer"
+                          xmlns:rxui="http://reactiveui.net"
+                          xmlns:moduleExplorerVM="clr-namespace:Reemit.Gui.ViewModels.Controls.ModuleExplorer"
+                          mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+                          x:Class="Reemit.Gui.Views.Controls.ModuleExplorer.ModuleExplorerClassNodeView">
+    <moduleExplorer:ModuleExplorerNodeView Name="NodeView" IconKind="Class" />
 </rxui:ReactiveUserControl>

--- a/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerClassNodeView.axaml.cs
+++ b/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerClassNodeView.axaml.cs
@@ -1,0 +1,19 @@
+using System.Reactive.Disposables;
+using Avalonia.ReactiveUI;
+using ReactiveUI;
+using Reemit.Gui.ViewModels.Controls.ModuleExplorer;
+
+namespace Reemit.Gui.Views.Controls.ModuleExplorer;
+
+public partial class ModuleExplorerClassNodeView : ReactiveUserControl<ModuleExplorerClassNodeViewModel>
+{
+    public ModuleExplorerClassNodeView()
+    {
+        InitializeComponent();
+        this.WhenActivated(disposable =>
+        {
+            this.OneWayBind(ViewModel, vm => vm.Name, v => v.NodeView.Text)
+                .DisposeWith(disposable);
+        });
+    }
+}

--- a/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerInterfaceNodeView.axaml
+++ b/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerInterfaceNodeView.axaml
@@ -2,15 +2,10 @@
                           xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                           xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                           xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                          xmlns:icons="clr-namespace:Reemit.Gui.Views.Controls.Icons"
                           xmlns:moduleExplorer="clr-namespace:Reemit.Gui.Views.Controls.ModuleExplorer"
                           xmlns:rxui="http://reactiveui.net"
                           xmlns:moduleExplorerVM="clr-namespace:Reemit.Gui.ViewModels.Controls.ModuleExplorer"
                           mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
                           x:Class="Reemit.Gui.Views.Controls.ModuleExplorer.ModuleExplorerInterfaceNodeView">
-    <moduleExplorer:ModuleExplorerNodeView Name="NodeView">
-        <moduleExplorer:ModuleExplorerNodeView.Icon>
-            <icons:InterfaceIcon />
-        </moduleExplorer:ModuleExplorerNodeView.Icon>
-    </moduleExplorer:ModuleExplorerNodeView>
+    <moduleExplorer:ModuleExplorerNodeView Name="NodeView" IconKind="Interface" />
 </rxui:ReactiveUserControl>

--- a/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerInterfaceNodeView.axaml
+++ b/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerInterfaceNodeView.axaml
@@ -1,0 +1,16 @@
+<rxui:ReactiveUserControl x:TypeArguments="moduleExplorerVM:ModuleExplorerInterfaceNodeViewModel" xmlns="https://github.com/avaloniaui"
+                          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                          xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                          xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                          xmlns:icons="clr-namespace:Reemit.Gui.Views.Controls.Icons"
+                          xmlns:moduleExplorer="clr-namespace:Reemit.Gui.Views.Controls.ModuleExplorer"
+                          xmlns:rxui="http://reactiveui.net"
+                          xmlns:moduleExplorerVM="clr-namespace:Reemit.Gui.ViewModels.Controls.ModuleExplorer"
+                          mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+                          x:Class="Reemit.Gui.Views.Controls.ModuleExplorer.ModuleExplorerInterfaceNodeView">
+    <moduleExplorer:ModuleExplorerNodeView Name="NodeView">
+        <moduleExplorer:ModuleExplorerNodeView.Icon>
+            <icons:InterfaceIcon />
+        </moduleExplorer:ModuleExplorerNodeView.Icon>
+    </moduleExplorer:ModuleExplorerNodeView>
+</rxui:ReactiveUserControl>

--- a/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerInterfaceNodeView.axaml.cs
+++ b/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerInterfaceNodeView.axaml.cs
@@ -1,0 +1,19 @@
+using System.Reactive.Disposables;
+using Avalonia.ReactiveUI;
+using ReactiveUI;
+using Reemit.Gui.ViewModels.Controls.ModuleExplorer;
+
+namespace Reemit.Gui.Views.Controls.ModuleExplorer;
+
+public partial class ModuleExplorerInterfaceNodeView : ReactiveUserControl<ModuleExplorerInterfaceNodeViewModel>
+{
+    public ModuleExplorerInterfaceNodeView()
+    {
+        InitializeComponent();
+        this.WhenActivated(disposable =>
+        {
+            this.OneWayBind(ViewModel, vm => vm.Name, v => v.NodeView.Text)
+                .DisposeWith(disposable);
+        });
+    }
+}

--- a/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerModuleNodeView.axaml
+++ b/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerModuleNodeView.axaml
@@ -1,0 +1,17 @@
+<rxui:ReactiveUserControl x:TypeArguments="moduleExplorerVM:ModuleExplorerModuleNodeViewModel"
+                          xmlns="https://github.com/avaloniaui"
+                          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                          xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                          xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                          xmlns:icons="clr-namespace:Reemit.Gui.Views.Controls.Icons"
+                          xmlns:rxui="http://reactiveui.net"
+                          xmlns:moduleExplorerVM="clr-namespace:Reemit.Gui.ViewModels.Controls.ModuleExplorer"
+                          xmlns:moduleExplorer="clr-namespace:Reemit.Gui.Views.Controls.ModuleExplorer"
+                          mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+                          x:Class="Reemit.Gui.Views.Controls.ModuleExplorer.ModuleExplorerModuleNodeView">
+    <moduleExplorer:ModuleExplorerNodeView Name="NodeView">
+        <moduleExplorer:ModuleExplorerNodeView.Icon>
+            <icons:ModuleIcon />
+        </moduleExplorer:ModuleExplorerNodeView.Icon>
+    </moduleExplorer:ModuleExplorerNodeView>
+</rxui:ReactiveUserControl>

--- a/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerModuleNodeView.axaml
+++ b/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerModuleNodeView.axaml
@@ -3,15 +3,10 @@
                           xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                           xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                           xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                          xmlns:icons="clr-namespace:Reemit.Gui.Views.Controls.Icons"
                           xmlns:rxui="http://reactiveui.net"
                           xmlns:moduleExplorerVM="clr-namespace:Reemit.Gui.ViewModels.Controls.ModuleExplorer"
                           xmlns:moduleExplorer="clr-namespace:Reemit.Gui.Views.Controls.ModuleExplorer"
                           mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
                           x:Class="Reemit.Gui.Views.Controls.ModuleExplorer.ModuleExplorerModuleNodeView">
-    <moduleExplorer:ModuleExplorerNodeView Name="NodeView">
-        <moduleExplorer:ModuleExplorerNodeView.Icon>
-            <icons:ModuleIcon />
-        </moduleExplorer:ModuleExplorerNodeView.Icon>
-    </moduleExplorer:ModuleExplorerNodeView>
+    <moduleExplorer:ModuleExplorerNodeView Name="NodeView" IconKind="Module" />
 </rxui:ReactiveUserControl>

--- a/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerModuleNodeView.axaml.cs
+++ b/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerModuleNodeView.axaml.cs
@@ -1,0 +1,19 @@
+using System.Reactive.Disposables;
+using Avalonia.ReactiveUI;
+using ReactiveUI;
+using Reemit.Gui.ViewModels.Controls.ModuleExplorer;
+
+namespace Reemit.Gui.Views.Controls.ModuleExplorer;
+
+public partial class ModuleExplorerModuleNodeView : ReactiveUserControl<ModuleExplorerModuleNodeViewModel>
+{
+    public ModuleExplorerModuleNodeView()
+    {
+        InitializeComponent();
+        this.WhenActivated(disposable =>
+        {
+            this.OneWayBind(ViewModel, vm => vm.Name, v => v.NodeView.Text)
+                .DisposeWith(disposable);
+        });
+    }
+}

--- a/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerNamespaceNodeView.axaml
+++ b/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerNamespaceNodeView.axaml
@@ -5,13 +5,8 @@
                           xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                           xmlns:moduleExplorer="clr-namespace:Reemit.Gui.Views.Controls.ModuleExplorer"
                           xmlns:rxui="http://reactiveui.net"
-                          xmlns:icons="clr-namespace:Reemit.Gui.Views.Controls.Icons"
                           xmlns:moduleExplorerVM="clr-namespace:Reemit.Gui.ViewModels.Controls.ModuleExplorer"
                           mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
                           x:Class="Reemit.Gui.Views.Controls.ModuleExplorer.ModuleExplorerNamespaceNodeView">
-    <moduleExplorer:ModuleExplorerNodeView Name="NodeView">
-        <moduleExplorer:ModuleExplorerNodeView.Icon>
-            <icons:NamespaceIcon />
-        </moduleExplorer:ModuleExplorerNodeView.Icon>
-    </moduleExplorer:ModuleExplorerNodeView>
+    <moduleExplorer:ModuleExplorerNodeView Name="NodeView" IconKind="Namespace" />
 </rxui:ReactiveUserControl>

--- a/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerNamespaceNodeView.axaml
+++ b/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerNamespaceNodeView.axaml
@@ -1,0 +1,17 @@
+<rxui:ReactiveUserControl x:TypeArguments="moduleExplorerVM:ModuleExplorerNamespaceNodeViewModel"
+                          xmlns="https://github.com/avaloniaui"
+                          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                          xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                          xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                          xmlns:moduleExplorer="clr-namespace:Reemit.Gui.Views.Controls.ModuleExplorer"
+                          xmlns:rxui="http://reactiveui.net"
+                          xmlns:icons="clr-namespace:Reemit.Gui.Views.Controls.Icons"
+                          xmlns:moduleExplorerVM="clr-namespace:Reemit.Gui.ViewModels.Controls.ModuleExplorer"
+                          mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+                          x:Class="Reemit.Gui.Views.Controls.ModuleExplorer.ModuleExplorerNamespaceNodeView">
+    <moduleExplorer:ModuleExplorerNodeView Name="NodeView">
+        <moduleExplorer:ModuleExplorerNodeView.Icon>
+            <icons:NamespaceIcon />
+        </moduleExplorer:ModuleExplorerNodeView.Icon>
+    </moduleExplorer:ModuleExplorerNodeView>
+</rxui:ReactiveUserControl>

--- a/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerNamespaceNodeView.axaml.cs
+++ b/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerNamespaceNodeView.axaml.cs
@@ -1,0 +1,19 @@
+using System.Reactive.Disposables;
+using Avalonia.ReactiveUI;
+using ReactiveUI;
+using Reemit.Gui.ViewModels.Controls.ModuleExplorer;
+
+namespace Reemit.Gui.Views.Controls.ModuleExplorer;
+
+public partial class ModuleExplorerNamespaceNodeView : ReactiveUserControl<ModuleExplorerNamespaceNodeViewModel>
+{
+    public ModuleExplorerNamespaceNodeView()
+    {
+        InitializeComponent();
+        this.WhenActivated(disposable =>
+        {
+            this.OneWayBind(ViewModel, vm => vm.Name, v => v.NodeView.Text)
+                .DisposeWith(disposable);
+        });
+    }
+}

--- a/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerNodeView.axaml
+++ b/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerNodeView.axaml
@@ -1,0 +1,12 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             DataContext="{Binding RelativeSource={RelativeSource Self}}"
+             x:Class="Reemit.Gui.Views.Controls.ModuleExplorer.ModuleExplorerNodeView">
+    <StackPanel Orientation="Horizontal" Spacing="8">
+        <ContentControl Content="{Binding Icon}"></ContentControl>
+        <TextBlock Name="ModuleNameTextBlock" Foreground="White" Text="{Binding Text}" />
+    </StackPanel>
+</UserControl>

--- a/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerNodeView.axaml
+++ b/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerNodeView.axaml
@@ -2,11 +2,12 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:icons="clr-namespace:Reemit.Gui.Views.Controls.Icons"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              DataContext="{Binding RelativeSource={RelativeSource Self}}"
              x:Class="Reemit.Gui.Views.Controls.ModuleExplorer.ModuleExplorerNodeView">
     <StackPanel Orientation="Horizontal" Spacing="8">
-        <ContentControl Content="{Binding Icon}"></ContentControl>
+        <icons:Icon Kind="{Binding IconKind}" />
         <TextBlock Name="ModuleNameTextBlock" Foreground="White" Text="{Binding Text}" />
     </StackPanel>
 </UserControl>

--- a/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerNodeView.axaml.cs
+++ b/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerNodeView.axaml.cs
@@ -1,0 +1,30 @@
+using Avalonia;
+using Avalonia.Controls;
+
+namespace Reemit.Gui.Views.Controls.ModuleExplorer;
+
+public partial class ModuleExplorerNodeView : UserControl
+{
+    public static readonly StyledProperty<object?> IconProperty =
+        AvaloniaProperty.Register<ModuleExplorerNodeView, object?>(nameof(Icon));
+    
+    public object? Icon
+    {
+        get => GetValue(IconProperty);
+        set => SetValue(IconProperty, value);
+    }
+    
+    public static readonly StyledProperty<string?> TextProperty =
+        AvaloniaProperty.Register<ModuleExplorerNodeView, string?>(nameof(Text));
+    
+    public string? Text
+    {
+        get => GetValue(TextProperty);
+        set => SetValue(TextProperty, value);
+    }
+
+    public ModuleExplorerNodeView()
+    {
+        InitializeComponent();
+    }
+}

--- a/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerNodeView.axaml.cs
+++ b/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerNodeView.axaml.cs
@@ -1,17 +1,22 @@
 using Avalonia;
 using Avalonia.Controls;
+using Reemit.Gui.Models;
+using Reemit.Gui.Views.Controls.Icons;
 
 namespace Reemit.Gui.Views.Controls.ModuleExplorer;
 
 public partial class ModuleExplorerNodeView : UserControl
 {
-    public static readonly StyledProperty<object?> IconProperty =
-        AvaloniaProperty.Register<ModuleExplorerNodeView, object?>(nameof(Icon));
+    public static readonly DirectProperty<ModuleExplorerNodeView, IconKind> IconKindProperty =
+        Icon.KindProperty.AddOwner<ModuleExplorerNodeView>(o => o.IconKind,
+            (o, v) => o.IconKind = v);
+
+    private IconKind _iconKind = IconKind.Class;
     
-    public object? Icon
+    public IconKind IconKind
     {
-        get => GetValue(IconProperty);
-        set => SetValue(IconProperty, value);
+        get => _iconKind;
+        set => SetAndRaise(IconKindProperty, ref _iconKind, value);
     }
     
     public static readonly StyledProperty<string?> TextProperty =

--- a/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerStructNodeView.axaml
+++ b/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerStructNodeView.axaml
@@ -1,0 +1,11 @@
+<rxui:ReactiveUserControl x:TypeArguments="moduleExplorerVM:ModuleExplorerStructNodeViewModel" xmlns="https://github.com/avaloniaui"
+                                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                                xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                                xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                                xmlns:moduleExplorer="clr-namespace:Reemit.Gui.Views.Controls.ModuleExplorer"
+                                xmlns:rxui="http://reactiveui.net"
+                                xmlns:moduleExplorerVM="clr-namespace:Reemit.Gui.ViewModels.Controls.ModuleExplorer"
+                                mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+                                x:Class="Reemit.Gui.Views.Controls.ModuleExplorer.ModuleExplorerStructNodeView">
+    <moduleExplorer:ModuleExplorerNodeView Name="NodeView" IconKind="Structure" />
+</rxui:ReactiveUserControl>

--- a/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerStructNodeView.axaml.cs
+++ b/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerStructNodeView.axaml.cs
@@ -1,0 +1,19 @@
+using System.Reactive.Disposables;
+using Avalonia.ReactiveUI;
+using ReactiveUI;
+using Reemit.Gui.ViewModels.Controls.ModuleExplorer;
+
+namespace Reemit.Gui.Views.Controls.ModuleExplorer;
+
+public partial class ModuleExplorerStructNodeView : ReactiveUserControl<ModuleExplorerStructNodeViewModel>
+{
+    public ModuleExplorerStructNodeView()
+    {
+        InitializeComponent();
+        this.WhenActivated(disposable =>
+        {
+            this.OneWayBind(ViewModel, vm => vm.Name, v => v.NodeView.Text)
+                .DisposeWith(disposable);
+        });
+    }
+}

--- a/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerTreeView.axaml
+++ b/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerTreeView.axaml
@@ -22,6 +22,9 @@
             <DataTemplate DataType="moduleExplorerVM:ModuleExplorerInterfaceNodeViewModel">
                 <moduleExplorer:ModuleExplorerInterfaceNodeView DataContext="{Binding .}" />
             </DataTemplate>
+            <DataTemplate DataType="moduleExplorerVM:ModuleExplorerStructNodeViewModel">
+                <moduleExplorer:ModuleExplorerStructNodeView DataContext="{Binding .}" />
+            </DataTemplate>
         </TreeView.DataTemplates>
     </TreeView>
 </rxui:ReactiveUserControl>

--- a/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerTreeView.axaml
+++ b/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerTreeView.axaml
@@ -1,0 +1,27 @@
+<rxui:ReactiveUserControl x:TypeArguments="moduleExplorerVM:ModuleExplorerTreeViewModel"
+                          xmlns="https://github.com/avaloniaui"
+                          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                          xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                          xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                          xmlns:rxui="http://reactiveui.net"
+                          xmlns:moduleExplorer="clr-namespace:Reemit.Gui.Views.Controls.ModuleExplorer"
+                          xmlns:moduleExplorerVM="clr-namespace:Reemit.Gui.ViewModels.Controls.ModuleExplorer"
+                          mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+                          x:Class="Reemit.Gui.Views.Controls.ModuleExplorer.ModuleExplorerTreeView">
+    <TreeView Name="TreeView">
+        <TreeView.DataTemplates>
+            <TreeDataTemplate DataType="moduleExplorerVM:ModuleExplorerModuleNodeViewModel" ItemsSource="{Binding Children}">
+                <moduleExplorer:ModuleExplorerModuleNodeView DataContext="{Binding .}" />
+            </TreeDataTemplate>
+            <TreeDataTemplate DataType="moduleExplorerVM:ModuleExplorerNamespaceNodeViewModel" ItemsSource="{Binding Children}">
+                <moduleExplorer:ModuleExplorerNamespaceNodeView DataContext="{Binding .}" />
+            </TreeDataTemplate>
+            <DataTemplate DataType="moduleExplorerVM:ModuleExplorerClassNodeViewModel">
+                <moduleExplorer:ModuleExplorerClassNodeView DataContext="{Binding .}" />
+            </DataTemplate>
+            <DataTemplate DataType="moduleExplorerVM:ModuleExplorerInterfaceNodeViewModel">
+                <moduleExplorer:ModuleExplorerInterfaceNodeView DataContext="{Binding .}" />
+            </DataTemplate>
+        </TreeView.DataTemplates>
+    </TreeView>
+</rxui:ReactiveUserControl>

--- a/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerTreeView.axaml.cs
+++ b/Reemit.Gui/Views/Controls/ModuleExplorer/ModuleExplorerTreeView.axaml.cs
@@ -1,0 +1,19 @@
+using System.Reactive.Disposables;
+using Avalonia.ReactiveUI;
+using ReactiveUI;
+using Reemit.Gui.ViewModels.Controls.ModuleExplorer;
+
+namespace Reemit.Gui.Views.Controls.ModuleExplorer;
+
+public partial class ModuleExplorerTreeView : ReactiveUserControl<ModuleExplorerTreeViewModel>
+{
+    public ModuleExplorerTreeView()
+    {
+        InitializeComponent();
+        this.WhenActivated(disposable =>
+        {
+            this.OneWayBind(ViewModel, vm => vm.RootNodes, v => v.TreeView.ItemsSource)
+                .DisposeWith(disposable);
+        });
+    }
+}

--- a/Reemit.Gui/Views/HomeView.axaml
+++ b/Reemit.Gui/Views/HomeView.axaml
@@ -4,7 +4,8 @@
                           xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                           xmlns:rxui="http://reactiveui.net"
                           xmlns:viewModels="clr-namespace:Reemit.Gui.ViewModels"
+                          xmlns:moduleExplorer="clr-namespace:Reemit.Gui.Views.Controls.ModuleExplorer"
                           mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
                           x:Class="Reemit.Gui.Views.HomeView">
-    <TextBox AcceptsReturn="True" Name="OpenAssembliesText" />
+    <moduleExplorer:ModuleExplorerTreeView Name="ModuleExplorerTreeView" />
 </rxui:ReactiveUserControl>

--- a/Reemit.Gui/Views/HomeView.axaml.cs
+++ b/Reemit.Gui/Views/HomeView.axaml.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Linq;
 using System.Reactive.Disposables;
 using Avalonia.ReactiveUI;
 using ReactiveUI;
@@ -15,8 +13,7 @@ public partial class HomeView : ReactiveUserControl<HomeViewModel>
 
         this.WhenActivated(disposable =>
         {
-            this.OneWayBind(ViewModel, vm => vm.Modules, v => v.OpenAssembliesText.Text,
-                    v => string.Join(Environment.NewLine, v.Select(x => x.DebugDump())))
+            this.OneWayBind(ViewModel, vm => vm.ModuleExplorerTreeViewModel, v => v.ModuleExplorerTreeView.ViewModel)
                 .DisposeWith(disposable);
         });
     }


### PR DESCRIPTION
This adds a simple `TreeView` control that can be used to explore namespaces and types that are present in currently loaded module. Proper flags parsing had to be implemented inside of `TypeDef` to extract all present information about loaded type. All icons that are included in this PR are a part of the [Visual Studio Image Library](https://www.microsoft.com/en-us/download/details.aspx?id=35825).

<img width="817" alt="image" src="https://github.com/v0idzz/Reemit/assets/12448522/df1faa3b-d99b-470b-86e6-7f027ff31e5c">
