### PR TITLE
Implement reading COR_ILMETHOD struct

### DIFF
--- a/Reemit.Common.UnitTests/SharedReaderTests.cs
+++ b/Reemit.Common.UnitTests/SharedReaderTests.cs
@@ -228,7 +228,7 @@ public sealed class SharedReaderTests
     }
 
     [Fact]
-    public void CreateDerivedAtRelativeOffset_Called_RelativeOffsetSet()
+    public void CreateDerivedAtRelativeToStartOffset_Called_RelativeToStartOffsetSet()
     {
         // Arrange
         using var stream = new MemoryStream();
@@ -238,12 +238,35 @@ public sealed class SharedReaderTests
         const int derivedSharedReaderOffset = 2;
 
         // Act
-        var actualDerivedSharedReader = sharedReader.CreateDerivedAtRelativeOffset(derivedSharedReaderOffset);
+        var actualDerivedSharedReader = sharedReader.CreateDerivedAtRelativeToStartOffset(derivedSharedReaderOffset);
 
         // Assert
         Assert.Equal(sharedReaderOffset, sharedReader.Offset);
         Assert.Equal(0, sharedReader.RelativeOffset);
         Assert.Equal(sharedReaderOffset + derivedSharedReaderOffset, actualDerivedSharedReader.Offset);
+        Assert.Equal(0, actualDerivedSharedReader.RelativeOffset);
+    }
+    
+    [Fact]
+    public void CreateDerivedAtRelativeToCurrentOffset_Called_RelativeToCurrentOffsetSet()
+    {
+        // Arrange
+        byte[] bytes = [0x00, 0x01, 0x02, 0x03];
+        using var stream = new MemoryStream(bytes);
+        using var binaryReader = new BinaryReader(stream);
+        const int sharedReaderOffset = 1;
+        using var sharedReader = new SharedReader(sharedReaderOffset, binaryReader, new object());
+        sharedReader.ReadByte();
+        const int readDataSize = sizeof(byte);
+        const int derivedSharedReaderOffset = 2;
+
+        // Act
+        var actualDerivedSharedReader = sharedReader.CreateDerivedAtRelativeToCurrentOffset(derivedSharedReaderOffset);
+
+        // Assert
+        Assert.Equal(sharedReaderOffset + readDataSize, sharedReader.Offset);
+        Assert.Equal(readDataSize, sharedReader.RelativeOffset);
+        Assert.Equal(sharedReaderOffset + derivedSharedReaderOffset + readDataSize, actualDerivedSharedReader.Offset);
         Assert.Equal(0, actualDerivedSharedReader.RelativeOffset);
     }
 }

--- a/Reemit.Common/SharedReader.cs
+++ b/Reemit.Common/SharedReader.cs
@@ -94,7 +94,9 @@ public class SharedReader(int startOffset, BinaryReader reader, object lockObj) 
 
     public RangeMapped<byte> ReadMappedByte() => ReadMapped(base.ReadByte);
 
-    public SharedReader CreateDerivedAtRelativeOffset(uint relativeOffset) => new((int)(_startOffset + relativeOffset), this, lockObj);
+    public SharedReader CreateDerivedAtRelativeToStartOffset(uint relativeOffset) => new((int)(_startOffset + relativeOffset), this, lockObj);
+    
+    public SharedReader CreateDerivedAtRelativeToCurrentOffset(uint relativeOffset) => new((int)(Offset + relativeOffset), this, lockObj);
 
     public override int Read(byte[] buffer, int index, int count) => throw new NotImplementedException();
 

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/FatExceptionClauseTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/FatExceptionClauseTests.cs
@@ -1,0 +1,46 @@
+using Reemit.Common;
+using Reemit.Decompiler.Clr.Methods;
+
+namespace Reemit.Decompiler.Clr.UnitTests.Metadata.Methods;
+
+public class FatExceptionClauseTests
+{
+    [Fact]
+    public async Task Read_ValidFatExceptionClause_ReadsFatExceptionClause()
+    {
+        // Arrange
+        byte[] bytes =
+        [
+            // Flags
+            0x00, 0x00, 0x00, 0x00,
+            
+            // TryOffset
+            0x07, 0x00, 0x00, 0x00,
+            
+            // TryLength
+            0x21, 0x02, 0x00, 0x00,
+            
+            // HandlerOffset
+            0x28, 0x02, 0x00, 0x00,
+            
+            // HandlerLength
+            0x36, 0x00, 0x00, 0x00,
+            
+            // ClassTokenOrFilterOffset
+            0x1F, 0x00, 0x00, 0x01
+        ];
+        await using var memoryStream = new MemoryStream(bytes);
+        using var reader = new BinaryReader(memoryStream);
+
+        // Act
+        var clause = FatExceptionClause.Read(new SharedReader(0, reader, new object()));
+        
+        // Assert
+        Assert.Equal(CorILExceptionClauses.Exception, clause.Flags);
+        Assert.Equal(7u, clause.TryOffset);
+        Assert.Equal(545u, clause.TryLength);
+        Assert.Equal(552u, clause.HandlerOffset);
+        Assert.Equal(54u, clause.HandlerLength);
+        Assert.Equal(16777247u, clause.ClassTokenOrFilterOffset);
+    }
+}

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/FatExceptionHeaderTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/FatExceptionHeaderTests.cs
@@ -1,0 +1,35 @@
+using Reemit.Common;
+using Reemit.Decompiler.Clr.Methods;
+
+namespace Reemit.Decompiler.Clr.UnitTests.Metadata.Methods;
+
+public class FatExceptionHeaderTests
+{
+    [Fact]
+    public async Task Read_ValidFatExceptionHeader_ReadsFatExceptionHeader()
+    {
+        // Arrange
+        byte[] bytes =
+        [
+            // Kind
+            0x41,
+            
+            // DataSize
+            0x1C, 0x00, 0x00,
+            
+            // Clause (see FatExceptionClauseTests)
+            0x00, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00, 0x21, 0x02, 0x00, 0x00, 0x28, 0x02,
+            0x00, 0x00, 0x36, 0x00, 0x00, 0x00, 0x1F, 0x00, 0x00, 0x01
+        ];
+        await using var memoryStream = new MemoryStream(bytes);
+        using var reader = new BinaryReader(memoryStream);
+        
+        // Act
+        var header = FatExceptionHeader.Read(new SharedReader(0, reader, new object()));
+        
+        // Assert
+        Assert.Equal(CorILMethodSectionFlags.EHTable | CorILMethodSectionFlags.FatFormat, header.Kind);
+        Assert.Equal(28u, header.DataSize);
+        Assert.Single(header.Clauses);
+    }
+}

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/FatMethodHeaderTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/FatMethodHeaderTests.cs
@@ -1,0 +1,41 @@
+using Reemit.Common;
+using Reemit.Decompiler.Clr.Methods;
+
+namespace Reemit.Decompiler.Clr.UnitTests.Metadata.Methods;
+
+public class FatMethodHeaderTests
+{
+    [Fact]
+    public async Task Read_ValidFatMethodHeader_ReadsFatMethodHeader()
+    {
+        // Arrange
+        byte[] bytes = 
+        [
+            // Flags (12 bits) and Size (4 bits)
+            0x13, 0x30, 
+            
+            // MaxStack
+            0x02, 0x00,
+            
+            // CodeSize
+            0x40, 0x00, 0x00, 0x00,
+            
+            // LocalVarSigTok
+            0x14, 0x00, 0x00, 0x11
+        ];
+        await using var memoryStream = new MemoryStream(bytes);
+        using var reader = new BinaryReader(memoryStream);
+
+        // Act
+        var header =
+            FatMethodHeader.Read(new SharedReader(0, reader, new object()));
+
+        // Assert
+        Assert.Equal(CorILMethodFlags.FatFormat | CorILMethodFlags.TinyFormat | CorILMethodFlags.InitLocals,
+            header.Flags);
+        Assert.Equal(3u, header.Size);
+        Assert.Equal(2u, header.MaxStack);
+        Assert.Equal(64u, header.CodeSize);
+        Assert.Equal(285212692u, header.LocalVarSigTok);
+    }
+}

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/FatMethodHeaderTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/FatMethodHeaderTests.cs
@@ -31,8 +31,8 @@ public class FatMethodHeaderTests
             FatMethodHeader.Read(new SharedReader(0, reader, new object()));
 
         // Assert
-        Assert.Equal(CorILMethodFlags.FatFormat | CorILMethodFlags.TinyFormat | CorILMethodFlags.InitLocals,
-            header.Flags);
+        Assert.True(header.Flags.HasFlag(CorILMethodFlags.InitLocals));
+        Assert.Equal(CorILMethodFormat.Fat, (CorILMethodFormat)(header.Flags & CorILMethodFlags.FormatMask));
         Assert.Equal(3u, header.Size);
         Assert.Equal(2u, header.MaxStack);
         Assert.Equal(64u, header.CodeSize);

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/MethodDataSectionsReaderTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/MethodDataSectionsReaderTests.cs
@@ -1,0 +1,43 @@
+using Reemit.Common;
+using Reemit.Decompiler.Clr.Methods;
+
+namespace Reemit.Decompiler.Clr.UnitTests.Metadata.Methods;
+
+public class MethodDataSectionsReaderTests
+{
+    [Fact]
+    public async Task ReadMethodDataSections_SharedReaderNotPaddedTo4ByteBoundary_AppliesPaddingAndReadsSections()
+    {
+        // Arrange
+        byte[] bytes =
+        [
+            // Padding
+            0x00, 0x00, 0x00, 0x00,
+
+            // MoreSects
+            0b10000000
+            |
+
+            // SmallExceptionHeader
+            0x01,
+            0x10, 0x00, 0x00, 0x02, 0x00, 0x13, 0x00, 0x23, 0x36, 0x00, 0x0A, 0x00, 0x00, 0x00, 0x0,
+
+            // FatExceptionHeader
+            0x41,
+            0x1C, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00, 0x21, 0x02, 0x00, 0x00, 0x28, 0x02, 0x00, 0x00, 0x36, 0x00,
+            0x00, 0x00, 0x1F, 0x00, 0x00, 0x01
+        ];
+        await using var memoryStream = new MemoryStream(bytes);
+        using var reader = new BinaryReader(memoryStream);
+
+        // Act
+        var sections = MethodDataSectionsReader.ReadMethodDataSections(new SharedReader(2, reader, new object()))
+            .ToArray();
+
+        // Assert
+        Assert.Collection(sections,
+            s1 => Assert.IsType<SmallExceptionHeader>(s1),
+            s2 => Assert.IsType<FatExceptionHeader>(s2));
+    }
+}

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/MethodHeaderReaderTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/MethodHeaderReaderTests.cs
@@ -12,12 +12,12 @@ public class MethodHeaderReaderTests
         byte[] bytes = 
         [
             // Type of header
-            0b10
+            0b00000010
 
             |
 
             // CodeSize (see TinyMethodHeaderTests)
-            0b100000
+            0b00100000
         ];
         await using var memoryStream = new MemoryStream(bytes);
         using var reader = new BinaryReader(memoryStream);
@@ -36,12 +36,12 @@ public class MethodHeaderReaderTests
         byte[] bytes = 
         [
             // Type of header
-            0b11
+            0b00000011
 
             |
 
             // FatMethodHeader (see FatMethodHeaderTests)
-            0b1000, 0x30,
+            0b00001000, 0x30,
             0x02, 0x00,
             0x40, 0x00, 0x00, 0x00,
             0x14, 0x00, 0x00, 0x11

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/MethodHeaderReaderTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/MethodHeaderReaderTests.cs
@@ -1,0 +1,58 @@
+using Reemit.Common;
+using Reemit.Decompiler.Clr.Methods;
+
+namespace Reemit.Decompiler.Clr.UnitTests.Metadata.Methods;
+
+public class MethodHeaderReaderTests
+{
+    [Fact]
+    public async Task ReadMethodHeader_TinyFormatBitsSet_ReadsTinyFormatHeader()
+    {
+        // Arrange
+        byte[] bytes = 
+        [
+            // Type of header
+            0b10
+
+            |
+
+            // CodeSize (see TinyMethodHeaderTests)
+            0b100000
+        ];
+        await using var memoryStream = new MemoryStream(bytes);
+        using var reader = new BinaryReader(memoryStream);
+
+        // Act
+        var header = MethodHeaderReader.ReadMethodHeader(new SharedReader(0, reader, new object()));
+
+        // Assert
+        Assert.IsType<TinyMethodHeader>(header);
+    }
+    
+    [Fact]
+    public async Task ReadMethodHeader_FatFormatBitsSet_ReadsFatFormatHeader()
+    {
+        // Arrange
+        byte[] bytes = 
+        [
+            // Type of header
+            0b11
+
+            |
+
+            // FatMethodHeader (see FatMethodHeaderTests)
+            0b1000, 0x30,
+            0x02, 0x00,
+            0x40, 0x00, 0x00, 0x00,
+            0x14, 0x00, 0x00, 0x11
+        ];
+        await using var memoryStream = new MemoryStream(bytes);
+        using var reader = new BinaryReader(memoryStream);
+
+        // Act
+        var header = MethodHeaderReader.ReadMethodHeader(new SharedReader(0, reader, new object()));
+
+        // Assert
+        Assert.IsType<FatMethodHeader>(header);
+    }
+}

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/SmallExceptionClauseTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/SmallExceptionClauseTests.cs
@@ -1,0 +1,46 @@
+using Reemit.Common;
+using Reemit.Decompiler.Clr.Methods;
+
+namespace Reemit.Decompiler.Clr.UnitTests.Metadata.Methods;
+
+public class SmallExceptionClauseTests
+{
+    [Fact]
+    public async Task Read_ValidSmallExceptionClause_ReadsSmallExceptionClause()
+    {
+        // Arrange
+        byte[] bytes = 
+        [
+            // Flags
+            0x00, 0x00,
+            
+            // TryOffset
+            0x07, 0x00,
+            
+            // TryLength
+            0xBA,
+            
+            // HandlerOffset
+            0xC1, 0x00,
+            
+            // HandlerLength
+            0x21,
+            
+            // ClassTokenOrFilterOffset
+            0x1F, 0x00, 0x00, 0x01
+        ];
+        await using var memoryStream = new MemoryStream(bytes);
+        using var reader = new BinaryReader(memoryStream);
+
+        // Act
+        var clause = SmallExceptionClause.Read(new SharedReader(0, reader, new object()));
+        
+        // Assert
+        Assert.Equal(CorILExceptionClauses.Exception, clause.Flags);
+        Assert.Equal(7u, clause.TryOffset);
+        Assert.Equal(186u, clause.TryLength);
+        Assert.Equal(193u, clause.HandlerOffset);
+        Assert.Equal(33u, clause.HandlerLength);
+        Assert.Equal(16777247u, clause.ClassTokenOrFilterOffset);
+    }
+}

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/SmallExceptionHeaderTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/SmallExceptionHeaderTests.cs
@@ -1,0 +1,70 @@
+using Reemit.Common;
+using Reemit.Decompiler.Clr.Metadata;
+using Reemit.Decompiler.Clr.Metadata.Tables;
+using Reemit.Decompiler.Clr.Methods;
+
+namespace Reemit.Decompiler.Clr.UnitTests.Metadata.Methods;
+
+public class SmallExceptionHeaderTests
+{
+    [Fact]
+    public async Task Read_ValidSmallExceptionHeader_ReadsSmallExceptionHeader()
+    {
+        // Arrange
+        byte[] bytes =
+        [
+            // Kind
+            0x01,
+
+            // DataSize
+            0x10,
+
+            // Reserved
+            0x00, 0x00, 0x00, 0x00,
+
+            // Clause (see SmallExceptionClauseTests)
+            0x07, 0x00, 0xBA, 0xC1, 0x00, 0x21, 0x1F, 0x00, 0x00, 0x01
+        ];
+        await using var memoryStream = new MemoryStream(bytes);
+        using var reader = new BinaryReader(memoryStream);
+
+        // Act
+        var header = SmallExceptionHeader.Read(new SharedReader(0, reader, new object()));
+
+        // Assert
+        Assert.Equal(CorILMethodSectionFlags.EHTable, header.Kind);
+        Assert.Equal(16u, header.DataSize);
+        Assert.Equal(0u, header.Reserved);
+        Assert.Single(header.Clauses);
+    }
+
+    [Fact]
+    public async Task Read_SmallExceptionHeaderWithNonZeroReservedBytes_Throws()
+    {
+        // Arrange
+        byte[] bytes =
+        [
+            // Kind
+            0x01,
+
+            // DataSize
+            0x10,
+
+            // Reserved
+            0xFF, 0xFF, 0xFF, 0xFF,
+
+            // Clause (see SmallExceptionClauseTests)
+            0x07, 0x00, 0xBA, 0xC1, 0x00, 0x21, 0x1F, 0x00, 0x00, 0x01
+        ];
+        await using var memoryStream = new MemoryStream(bytes);
+        using var reader = new BinaryReader(memoryStream);
+
+        // Act
+        var act = () =>
+            SmallExceptionHeader.Read(new MetadataTableDataReader(reader, 0,
+                new Dictionary<MetadataTableName, uint>()));
+
+        // Assert
+        Assert.Throws<BadImageFormatException>(act);
+    }
+}

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/TinyMethodHeaderTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/TinyMethodHeaderTests.cs
@@ -1,0 +1,31 @@
+using Reemit.Common;
+using Reemit.Decompiler.Clr.Methods;
+
+namespace Reemit.Decompiler.Clr.UnitTests.Metadata.Methods;
+
+public class TinyMethodHeaderTests
+{
+    [Fact]
+    public async Task Read_ValidTinyMethodHeader_ReadsTinyMethodHeader()
+    {
+        // Arrange
+        byte[] bytes =
+        [
+            // CodeSize
+            0b100000
+            
+            |
+            
+            // Type of header
+            0b10
+        ];
+        await using var memoryStream = new MemoryStream(bytes);
+        using var reader = new BinaryReader(memoryStream);
+
+        // Act
+        var header = TinyMethodHeader.Read(new SharedReader(0, reader, new object()));
+        
+        // Assert
+        Assert.Equal(32u, header.CodeSize);
+    }
+}

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/TinyMethodHeaderTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/TinyMethodHeaderTests.cs
@@ -12,12 +12,12 @@ public class TinyMethodHeaderTests
         byte[] bytes =
         [
             // CodeSize
-            0b100000
+            0b00100000
             
             |
             
             // Type of header
-            0b10
+            0b00000010
         ];
         await using var memoryStream = new MemoryStream(bytes);
         using var reader = new BinaryReader(memoryStream);
@@ -26,6 +26,6 @@ public class TinyMethodHeaderTests
         var header = TinyMethodHeader.Read(new SharedReader(0, reader, new object()));
         
         // Assert
-        Assert.Equal(32u, header.CodeSize);
+        Assert.Equal(8u, header.CodeSize);
     }
 }

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Tables/FieldRowTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Tables/FieldRowTests.cs
@@ -6,7 +6,7 @@ namespace Reemit.Decompiler.Clr.UnitTests.Metadata.Tables;
 public class FieldRowTests
 {
     [Fact]
-    public async Task Constructor_ValidFieldRow_ReadsFieldRow()
+    public async Task Read_ValidFieldRow_ReadsFieldRow()
     {
         // Arrange
         byte[] bytes = [0x01, 0x00, 0x11, 0x00, 0x1E, 0x00];
@@ -14,7 +14,7 @@ public class FieldRowTests
         using var reader = new BinaryReader(memoryStream);
 
         // Act
-        var row = FieldRow.Read(new MetadataTableDataReader(reader, 0, new Dictionary<MetadataTableName, uint>()));
+        var row = FieldRow.Read(1, new MetadataTableDataReader(reader, 0, new Dictionary<MetadataTableName, uint>()));
         
         // Assert
         Assert.Equal(FieldAttributes.Private, row.Flags);

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Tables/MethodDefRowTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Tables/MethodDefRowTests.cs
@@ -175,7 +175,7 @@ public class MethodDefRowTests
             // other
             0x8e, 0x03, 0x10, 0x00, 0x01, 0x00
         })]
-    public void Constructor_InvalidMethodDefRow_ThrowsBadImageFormatException(byte[] bytes)
+    public void Read_InvalidMethodDefRow_ThrowsBadImageFormatException(byte[] bytes)
     {
         // Arrange
         using var memoryStream = new MemoryStream(bytes);
@@ -183,7 +183,7 @@ public class MethodDefRowTests
         var tableReader = new MetadataTableDataReader(reader, 0, new Dictionary<MetadataTableName, uint>());
 
         // Act
-        Action readRow = () => MethodDefRow.Read(tableReader);
+        Action readRow = () => MethodDefRow.Read(1, tableReader);
 
         // Assert
         Assert.Throws<BadImageFormatException>(readRow);
@@ -191,7 +191,7 @@ public class MethodDefRowTests
 
     [Theory]
     [MemberData(nameof(GetMethodDefData))]
-    public void Constructor_ValidMethodDefRow_ReadsMethodDefRow(
+    public void Read_ValidMethodDefRow_ReadsMethodDefRow(
         byte[] bytes,
         uint expectedRva,
         ushort expectedImplFlags,
@@ -231,7 +231,7 @@ public class MethodDefRowTests
         var tableReader = new MetadataTableDataReader(reader, 0, new Dictionary<MetadataTableName, uint>());
 
         // Act
-        var row = MethodDefRow.Read(tableReader);
+        var row = MethodDefRow.Read(1, tableReader);
 
         // Assert
         Assert.Equal(expectedRva, row.Rva);

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Tables/ModuleRowTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Tables/ModuleRowTests.cs
@@ -6,7 +6,7 @@ namespace Reemit.Decompiler.Clr.UnitTests.Metadata.Tables;
 public class ModuleRowTests
 {
     [Fact]
-    public async Task Constructor_ValidModuleRow_ReadsModuleRow()
+    public async Task Read_ValidModuleRow_ReadsModuleRow()
     {
         // Arrange
         byte[] bytes = [0x00, 0x00, 0x68, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00];
@@ -14,7 +14,7 @@ public class ModuleRowTests
         using var reader = new BinaryReader(memoryStream);
 
         // Act
-        var header = ModuleRow.Read(new MetadataTableDataReader(reader, 0, new Dictionary<MetadataTableName, uint>()));
+        var header = ModuleRow.Read(1, new MetadataTableDataReader(reader, 0, new Dictionary<MetadataTableName, uint>()));
         
         // Assert
         Assert.Equal([0, 0], header.Generation);

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Tables/TypeDefRowTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Tables/TypeDefRowTests.cs
@@ -6,7 +6,7 @@ namespace Reemit.Decompiler.Clr.UnitTests.Metadata.Tables;
 public class TypeDefRowTests
 {
     [Fact]
-    public async Task Constructor_ValidTypeDefRow_ReadsTypeDefRow()
+    public async Task Read_ValidTypeDefRow_ReadsTypeDefRow()
     {
         // Arrange
         byte[] bytes = [0x01, 0x00, 0x10, 0x00, 0x01, 0x00, 0xEB, 0x01, 0x35, 0x00, 0x01, 0x00, 0x01, 0x00];
@@ -14,7 +14,7 @@ public class TypeDefRowTests
         using var reader = new BinaryReader(memoryStream);
 
         // Act
-        var row = TypeDefRow.Read(new MetadataTableDataReader(reader, 0, new Dictionary<MetadataTableName, uint>
+        var row = TypeDefRow.Read(1, new MetadataTableDataReader(reader, 0, new Dictionary<MetadataTableName, uint>
         {
             { MetadataTableName.TypeRef, 1 },
             { MetadataTableName.Field, 1 },

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Tables/TypeRefRowTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Tables/TypeRefRowTests.cs
@@ -6,7 +6,7 @@ namespace Reemit.Decompiler.Clr.UnitTests.Metadata.Tables;
 public class TypeRefRowTests
 {
     [Fact]
-    public async Task Constructor_ValidTypeRefRow_ReadsTypeRefRow()
+    public async Task Read_ValidTypeRefRow_ReadsTypeRefRow()
     {
         // Arrange
         byte[] bytes = [0x06, 0x00, 0x2B, 0x00, 0xA2, 0x01];
@@ -14,7 +14,7 @@ public class TypeRefRowTests
         using var reader = new BinaryReader(memoryStream);
 
         // Act
-        var row = TypeRefRow.Read(new MetadataTableDataReader(reader, 0, new Dictionary<MetadataTableName, uint>
+        var row = TypeRefRow.Read(1, new MetadataTableDataReader(reader, 0, new Dictionary<MetadataTableName, uint>
         {
             { MetadataTableName.AssemblyRef, 1 }
         }));

--- a/Reemit.Decompiler.Clr/Metadata/Streams/MetadataTablesStream.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Streams/MetadataTablesStream.cs
@@ -19,11 +19,11 @@ public class MetadataTablesStream
     public MetadataTable<FieldRow>? Field { get; }
     public MetadataTable<MethodDefRow>? MethodDef { get; }
 
-    public IReadOnlyDictionary<MetadataTableName, IReadOnlyList<IMetadataTableRow>> Rows => _rows
-        .ToDictionary(x => x.Key, x => (IReadOnlyList<IMetadataTableRow>)x.Value.ToArray().AsReadOnly())
+    public IReadOnlyDictionary<MetadataTableName, IReadOnlyList<IMetadataRecord>> Rows => _rows
+        .ToDictionary(x => x.Key, x => (IReadOnlyList<IMetadataRecord>)x.Value.ToArray().AsReadOnly())
         .AsReadOnly();
 
-    private readonly Dictionary<MetadataTableName, List<IMetadataTableRow>> _rows;
+    private readonly Dictionary<MetadataTableName, List<IMetadataRecord>> _rows;
     private readonly MetadataTableDataReader _metadataTableDataReader;
 
     public MetadataTablesStream(BinaryReader reader)
@@ -38,14 +38,14 @@ public class MetadataTablesStream
         // var sortedBits = new BitArray(
         reader.ReadBytes(8);
 
-        _rows = new Dictionary<MetadataTableName, List<IMetadataTableRow>>(validBits.Count(x => x));
+        _rows = new Dictionary<MetadataTableName, List<IMetadataRecord>>(validBits.Count(x => x));
 
         foreach (var name in validBits
                      .Select((x, i) => (IsValid: x, TableName: (MetadataTableName)i))
                      .Where(x => x.IsValid)
                      .Select(x => x.TableName))
         {
-            _rows[name] = new List<IMetadataTableRow>((int)reader.ReadUInt32());
+            _rows[name] = new List<IMetadataRecord>((int)reader.ReadUInt32());
         }
 
         _metadataTableDataReader = new MetadataTableDataReader(reader, HeapSizes,
@@ -75,7 +75,7 @@ public class MetadataTablesStream
         }
 
         var table = new MetadataTable<T>((uint)list.Capacity, _metadataTableDataReader);
-        _rows[T.TableName].AddRange(table.Rows.Cast<IMetadataTableRow>());
+        _rows[T.TableName].AddRange(table.Rows.Cast<IMetadataRecord>());
 
         return table;
     }

--- a/Reemit.Decompiler.Clr/Metadata/Streams/StringsHeapStream.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Streams/StringsHeapStream.cs
@@ -18,7 +18,7 @@ public class StringsHeapStream
 
     public string Read(uint valueOffset)
     {
-        var reader = _reader.CreateDerivedAtRelativeOffset(valueOffset);
+        var reader = _reader.CreateDerivedAtRelativeToStartOffset(valueOffset);
 
         const int bufferSize = 16;
         var valBytes = new List<byte>(bufferSize);

--- a/Reemit.Decompiler.Clr/Metadata/TableReferenceResolver.cs
+++ b/Reemit.Decompiler.Clr/Metadata/TableReferenceResolver.cs
@@ -2,10 +2,11 @@ using Reemit.Decompiler.Clr.Metadata.Tables;
 
 namespace Reemit.Decompiler.Clr.Metadata;
 
-public class TableReferenceResolver(IReadOnlyDictionary<MetadataTableName, IReadOnlyList<IMetadataTableRow>> allTables)
+public class TableReferenceResolver(IReadOnlyDictionary<MetadataTableName, IReadOnlyList<IMetadataRecord>> allTables)
 {
-    public IReadOnlyList<IMetadataTableRow>
-        GetReferencedRows(CodedIndex codedIndex, IMetadataTableRow referencingRow) =>
+    public IReadOnlyList<IMetadataRecord>
+        GetReferencedRows<TRef>(CodedIndex codedIndex, TRef referencingRow)
+        where TRef : IMetadataTableRow =>
         codedIndex.GetReferencedRows(referencingRow, allTables);
 
     public IReadOnlyList<TTarget> GetReferencedRows<TRef, TTarget>(TRef referencingRow)
@@ -20,17 +21,17 @@ public class TableReferenceResolver(IReadOnlyDictionary<MetadataTableName, IRead
 
 public static class CodedIndexExtensions
 {
-    public static IReadOnlyList<IMetadataTableRow> GetReferencedRows<TRef>(this CodedIndex codedIndex,
+    public static IReadOnlyList<IMetadataRecord> GetReferencedRows<TRef>(this CodedIndex codedIndex,
         TRef referencingRow,
-        IReadOnlyDictionary<MetadataTableName, IReadOnlyList<IMetadataTableRow>> allTables)
+        IReadOnlyDictionary<MetadataTableName, IReadOnlyList<IMetadataRecord>> allTables)
         where TRef : IMetadataTableRow =>
         GetReferencedRows(referencingRow, allTables[TRef.TableName], allTables[codedIndex.ReferencedTable]);
 
     public static IReadOnlyList<TTarget> GetReferencedRows<TRef, TTarget>(TRef referencingRow,
         IReadOnlyList<TRef> referencingTableRows,
         IReadOnlyList<TTarget> referencedTableRows)
-        where TRef : IMetadataTableRow
-        where TTarget : IMetadataTableRow
+        where TRef : IMetadataRecord
+        where TTarget : IMetadataRecord
     {
         var nextRowInReferencingTable = referencingTableRows.SingleOrDefault(x => x.Rid - referencingRow.Rid == 1);
 

--- a/Reemit.Decompiler.Clr/Metadata/TableReferenceResolver.cs
+++ b/Reemit.Decompiler.Clr/Metadata/TableReferenceResolver.cs
@@ -1,0 +1,46 @@
+using Reemit.Decompiler.Clr.Metadata.Tables;
+
+namespace Reemit.Decompiler.Clr.Metadata;
+
+public class TableReferenceResolver(IReadOnlyDictionary<MetadataTableName, IReadOnlyList<IMetadataTableRow>> allTables)
+{
+    public IReadOnlyList<IMetadataTableRow>
+        GetReferencedRows(CodedIndex codedIndex, IMetadataTableRow referencingRow) =>
+        codedIndex.GetReferencedRows(referencingRow, allTables);
+
+    public IReadOnlyList<TTarget> GetReferencedRows<TRef, TTarget>(TRef referencingRow)
+        where TRef : IMetadataTableRow
+        where TTarget : IMetadataTableRow =>
+        CodedIndexExtensions.GetReferencedRows(referencingRow, allTables[TRef.TableName],
+                allTables[TTarget.TableName])
+            .Cast<TTarget>()
+            .ToArray()
+            .AsReadOnly();
+}
+
+public static class CodedIndexExtensions
+{
+    public static IReadOnlyList<IMetadataTableRow> GetReferencedRows<TRef>(this CodedIndex codedIndex,
+        TRef referencingRow,
+        IReadOnlyDictionary<MetadataTableName, IReadOnlyList<IMetadataTableRow>> allTables)
+        where TRef : IMetadataTableRow =>
+        GetReferencedRows(referencingRow, allTables[TRef.TableName], allTables[codedIndex.ReferencedTable]);
+
+    public static IReadOnlyList<TTarget> GetReferencedRows<TRef, TTarget>(TRef referencingRow,
+        IReadOnlyList<TRef> referencingTableRows,
+        IReadOnlyList<TTarget> referencedTableRows)
+        where TRef : IMetadataTableRow
+        where TTarget : IMetadataTableRow
+    {
+        var nextRowInReferencingTable = referencingTableRows.SingleOrDefault(x => x.Rid - referencingRow.Rid == 1);
+
+        var firstRowIndex = (int)(referencingRow.Rid - 1);
+        var lastRowIndex = (int?)(nextRowInReferencingTable?.Rid - 1) ?? referencedTableRows.Count - 1;
+
+        return referencedTableRows
+            .Skip(firstRowIndex)
+            .Take(lastRowIndex)
+            .ToArray()
+            .AsReadOnly();
+    }
+}

--- a/Reemit.Decompiler.Clr/Metadata/Tables/FieldRow.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/FieldRow.cs
@@ -1,7 +1,7 @@
 namespace Reemit.Decompiler.Clr.Metadata.Tables;
 
 public class FieldRow(uint rid, FieldAttributes flags, uint name, uint signature)
-    : MetadataTableRow<FieldRow>(rid), IMetadataTableRow<FieldRow>
+    : MetadataRecord(rid), IMetadataTableRow<FieldRow>
 {
     public static MetadataTableName TableName => MetadataTableName.Field;
 

--- a/Reemit.Decompiler.Clr/Metadata/Tables/FieldRow.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/FieldRow.cs
@@ -1,7 +1,7 @@
 namespace Reemit.Decompiler.Clr.Metadata.Tables;
 
-public class FieldRow(FieldAttributes flags, uint name, uint signature)
-    : IMetadataTableRow<FieldRow>
+public class FieldRow(uint rid, FieldAttributes flags, uint name, uint signature)
+    : MetadataTableRow<FieldRow>(rid), IMetadataTableRow<FieldRow>
 {
     public static MetadataTableName TableName => MetadataTableName.Field;
 
@@ -9,8 +9,9 @@ public class FieldRow(FieldAttributes flags, uint name, uint signature)
     public uint Name { get; } = name;
     public uint Signature { get; } = signature;
 
-    public static FieldRow Read(MetadataTableDataReader reader) =>
+    public static FieldRow Read(uint rid, MetadataTableDataReader reader) =>
         new(
+            rid,
             (FieldAttributes)(reader.ReadUInt16() & FlagMasks.FieldAccessMask),
             reader.ReadStringRid(),
             reader.ReadBlobRid());

--- a/Reemit.Decompiler.Clr/Metadata/Tables/IMetadataRecord.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/IMetadataRecord.cs
@@ -1,0 +1,21 @@
+namespace Reemit.Decompiler.Clr.Metadata.Tables;
+
+public abstract class MetadataRecord : IMetadataRecord
+{
+    protected MetadataRecord(uint rid)
+    {
+        if (rid == 0)
+        {
+            throw new ArgumentException("Invalid RID, expected number greater than 0", nameof(rid));
+        }
+
+        Rid = rid;
+    }
+
+    public uint Rid { get; }
+}
+
+public interface IMetadataRecord
+{
+    public uint Rid { get; }
+}

--- a/Reemit.Decompiler.Clr/Metadata/Tables/IMetadataRecord.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/IMetadataRecord.cs
@@ -1,20 +1,5 @@
 namespace Reemit.Decompiler.Clr.Metadata.Tables;
 
-public abstract class MetadataRecord : IMetadataRecord
-{
-    protected MetadataRecord(uint rid)
-    {
-        if (rid == 0)
-        {
-            throw new ArgumentException("Invalid RID, expected number greater than 0", nameof(rid));
-        }
-
-        Rid = rid;
-    }
-
-    public uint Rid { get; }
-}
-
 public interface IMetadataRecord
 {
     public uint Rid { get; }

--- a/Reemit.Decompiler.Clr/Metadata/Tables/IMetadataTableRow.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/IMetadataTableRow.cs
@@ -1,29 +1,12 @@
 namespace Reemit.Decompiler.Clr.Metadata.Tables;
 
-public abstract class MetadataTableRow<T> : IMetadataTableRow<T> where T : IMetadataTableRow<T>
+public interface IMetadataTableRow : IMetadataRecord
 {
-    protected MetadataTableRow(uint rid)
-    {
-        if (rid == 0)
-        {
-            throw new ArgumentException("Invalid RID, expected number greater than 0", nameof(rid));
-        }
-
-        Rid = rid;
-    }
-
-    public uint Rid { get; }
-}
-
-public interface IMetadataTableRow
-{
-    uint Rid { get; }
-
-    static virtual MetadataTableName TableName => throw new NotImplementedException();
+    static abstract MetadataTableName TableName { get; }
 }
 
 public interface IMetadataTableRow<out T> : IMetadataTableRow
     where T : IMetadataTableRow<T>
 {
-    static virtual T Read(uint rid, MetadataTableDataReader reader) => throw new NotImplementedException();
+    static abstract T Read(uint rid, MetadataTableDataReader reader);
 }

--- a/Reemit.Decompiler.Clr/Metadata/Tables/IMetadataTableRow.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/IMetadataTableRow.cs
@@ -1,12 +1,29 @@
 namespace Reemit.Decompiler.Clr.Metadata.Tables;
 
+public abstract class MetadataTableRow<T> : IMetadataTableRow<T> where T : IMetadataTableRow<T>
+{
+    protected MetadataTableRow(uint rid)
+    {
+        if (rid == 0)
+        {
+            throw new ArgumentException("Invalid RID, expected number greater than 0", nameof(rid));
+        }
+
+        Rid = rid;
+    }
+
+    public uint Rid { get; }
+}
+
 public interface IMetadataTableRow
 {
-    static abstract MetadataTableName TableName { get; }
+    uint Rid { get; }
+
+    static virtual MetadataTableName TableName => throw new NotImplementedException();
 }
 
 public interface IMetadataTableRow<out T> : IMetadataTableRow
     where T : IMetadataTableRow<T>
 {
-    static abstract T Read(MetadataTableDataReader reader);
+    static virtual T Read(uint rid, MetadataTableDataReader reader) => throw new NotImplementedException();
 }

--- a/Reemit.Decompiler.Clr/Metadata/Tables/MetadataRecord.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/MetadataRecord.cs
@@ -1,0 +1,16 @@
+namespace Reemit.Decompiler.Clr.Metadata.Tables;
+
+public abstract class MetadataRecord : IMetadataRecord
+{
+    protected MetadataRecord(uint rid)
+    {
+        if (rid == 0)
+        {
+            throw new ArgumentException("Invalid RID, expected number greater than 0", nameof(rid));
+        }
+
+        Rid = rid;
+    }
+
+    public uint Rid { get; }
+}

--- a/Reemit.Decompiler.Clr/Metadata/Tables/MetadataTable.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/MetadataTable.cs
@@ -8,9 +8,9 @@ public class MetadataTable<TRow> where TRow : IMetadataTableRow<TRow>
     {
         var rows = new List<TRow>((int) rowCount);
 
-        for (var i = 0; i < rowCount; i++)
+        for (var i = 0u; i < rowCount; i++)
         {
-            rows.Add(TRow.Read(reader));
+            rows.Add(TRow.Read(i + 1, reader));
         }
 
         Rows = rows.AsReadOnly();

--- a/Reemit.Decompiler.Clr/Metadata/Tables/MethodDefRow.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/MethodDefRow.cs
@@ -7,7 +7,7 @@ public class MethodDefRow(
     ushort flags,
     uint name,
     uint signature,
-    uint paramList) : MetadataTableRow<MethodDefRow>(rid), IMetadataTableRow<MethodDefRow>
+    uint paramList) : MetadataRecord(rid), IMetadataTableRow<MethodDefRow>
 {
     public static MetadataTableName TableName => MetadataTableName.MethodDef;
 

--- a/Reemit.Decompiler.Clr/Metadata/Tables/MethodDefRow.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/MethodDefRow.cs
@@ -1,14 +1,13 @@
-﻿using System.Diagnostics.CodeAnalysis;
-
-namespace Reemit.Decompiler.Clr.Metadata.Tables;
+﻿namespace Reemit.Decompiler.Clr.Metadata.Tables;
 
 public class MethodDefRow(
+    uint rid,
     uint rva,
     ushort implFlags,
     ushort flags,
     uint name,
     uint signature,
-    uint paramList) : IMetadataTableRow<MethodDefRow>
+    uint paramList) : MetadataTableRow<MethodDefRow>(rid), IMetadataTableRow<MethodDefRow>
 {
     public static MetadataTableName TableName => MetadataTableName.MethodDef;
 
@@ -60,7 +59,7 @@ public class MethodDefRow(
     public bool HasSecurity => MethodFlags.HasFlag(MethodAttributes.HasSecurity);
     public bool RequireSecObject => MethodFlags.HasFlag(MethodAttributes.RequireSecObject);
 
-    public static MethodDefRow Read(MetadataTableDataReader reader)
+    public static MethodDefRow Read(uint rid, MetadataTableDataReader reader)
     {
         var rva = reader.ReadUInt32();
 
@@ -84,6 +83,7 @@ public class MethodDefRow(
         var flags = reader.ReadUInt16();
         
         var row = new MethodDefRow(
+            rid,
             rva,
             implFlags,
             flags,

--- a/Reemit.Decompiler.Clr/Metadata/Tables/ModuleRow.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/ModuleRow.cs
@@ -1,7 +1,7 @@
 namespace Reemit.Decompiler.Clr.Metadata.Tables;
 
 public class ModuleRow(uint rid, byte[] generation, uint name, uint mvid, uint encId, uint encBaseId)
-    : MetadataTableRow<ModuleRow>(rid), IMetadataTableRow<ModuleRow>
+    : MetadataRecord(rid), IMetadataTableRow<ModuleRow>
 {
     public static MetadataTableName TableName => MetadataTableName.Module;
 

--- a/Reemit.Decompiler.Clr/Metadata/Tables/ModuleRow.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/ModuleRow.cs
@@ -1,7 +1,7 @@
 namespace Reemit.Decompiler.Clr.Metadata.Tables;
 
-public class ModuleRow(byte[] generation, uint name, uint mvid, uint encId, uint encBaseId)
-    : IMetadataTableRow<ModuleRow>
+public class ModuleRow(uint rid, byte[] generation, uint name, uint mvid, uint encId, uint encBaseId)
+    : MetadataTableRow<ModuleRow>(rid), IMetadataTableRow<ModuleRow>
 {
     public static MetadataTableName TableName => MetadataTableName.Module;
 
@@ -11,7 +11,7 @@ public class ModuleRow(byte[] generation, uint name, uint mvid, uint encId, uint
     public uint EncId { get; } = encId;
     public uint EncBaseId { get; } = encBaseId;
 
-    public static ModuleRow Read(MetadataTableDataReader reader)
+    public static ModuleRow Read(uint rid, MetadataTableDataReader reader)
     {
         var generation = reader.ReadBytes(2);
 
@@ -36,6 +36,6 @@ public class ModuleRow(byte[] generation, uint name, uint mvid, uint encId, uint
             throw new BadImageFormatException($"{nameof(encBaseId)} shall be zero.");
         }
 
-        return new(generation, name, mvid, encId, encBaseId);
+        return new(rid, generation, name, mvid, encId, encBaseId);
     }
 }

--- a/Reemit.Decompiler.Clr/Metadata/Tables/TypeDefRow.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/TypeDefRow.cs
@@ -1,13 +1,14 @@
 namespace Reemit.Decompiler.Clr.Metadata.Tables;
 
 public class TypeDefRow(
+    uint rid,
     uint flags,
     uint typeName,
     uint typeNamespace,
     CodedIndex extends,
     uint fieldList,
     uint methodList)
-    : IMetadataTableRow<TypeDefRow>
+    : MetadataTableRow<TypeDefRow>(rid), IMetadataTableRow<TypeDefRow>
 {
     public static MetadataTableName TableName => MetadataTableName.TypeDef;
 
@@ -33,7 +34,7 @@ public class TypeDefRow(
     public TypeVisibilityAttributes Visibility =>
         (TypeVisibilityAttributes)(Flags & (uint)TypeVisibilityAttributes.Mask);
 
-    public static TypeDefRow Read(MetadataTableDataReader reader)
+    public static TypeDefRow Read(uint rid, MetadataTableDataReader reader)
     {
         var flags = reader.ReadUInt32();
         var invalidFlags = flags & ~FlagMasks.TypeAttributesMask;
@@ -44,6 +45,7 @@ public class TypeDefRow(
         }
 
         return new TypeDefRow(
+            rid,
             flags,
             reader.ReadStringRid(),
             reader.ReadStringRid(),

--- a/Reemit.Decompiler.Clr/Metadata/Tables/TypeDefRow.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/TypeDefRow.cs
@@ -8,7 +8,7 @@ public class TypeDefRow(
     CodedIndex extends,
     uint fieldList,
     uint methodList)
-    : MetadataTableRow<TypeDefRow>(rid), IMetadataTableRow<TypeDefRow>
+    : MetadataRecord(rid), IMetadataTableRow<TypeDefRow>
 {
     public static MetadataTableName TableName => MetadataTableName.TypeDef;
 

--- a/Reemit.Decompiler.Clr/Metadata/Tables/TypeRefRow.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/TypeRefRow.cs
@@ -1,7 +1,7 @@
 namespace Reemit.Decompiler.Clr.Metadata.Tables;
 
-public class TypeRefRow(CodedIndex resolutionScope, uint typeName, uint typeNamespace)
-    : IMetadataTableRow<TypeRefRow>
+public class TypeRefRow(uint rid, CodedIndex resolutionScope, uint typeName, uint typeNamespace)
+    : MetadataTableRow<TypeRefRow>(rid), IMetadataTableRow<TypeRefRow>
 {
     public static MetadataTableName TableName => MetadataTableName.TypeRef;
 
@@ -9,8 +9,9 @@ public class TypeRefRow(CodedIndex resolutionScope, uint typeName, uint typeName
     public uint TypeName { get; } = typeName;
     public uint TypeNamespace { get; } = typeNamespace;
 
-    public static TypeRefRow Read(MetadataTableDataReader reader) =>
+    public static TypeRefRow Read(uint rid, MetadataTableDataReader reader) =>
         new(
+            rid,
             reader.ReadCodedRid(CodedIndexTagFamily.ResolutionScope),
             reader.ReadStringRid(),
             reader.ReadStringRid());

--- a/Reemit.Decompiler.Clr/Metadata/Tables/TypeRefRow.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/TypeRefRow.cs
@@ -1,7 +1,7 @@
 namespace Reemit.Decompiler.Clr.Metadata.Tables;
 
 public class TypeRefRow(uint rid, CodedIndex resolutionScope, uint typeName, uint typeNamespace)
-    : MetadataTableRow<TypeRefRow>(rid), IMetadataTableRow<TypeRefRow>
+    : MetadataRecord(rid), IMetadataTableRow<TypeRefRow>
 {
     public static MetadataTableName TableName => MetadataTableName.TypeRef;
 

--- a/Reemit.Decompiler.Clr/Methods/CorILExceptionClauses.cs
+++ b/Reemit.Decompiler.Clr/Methods/CorILExceptionClauses.cs
@@ -1,0 +1,12 @@
+namespace Reemit.Decompiler.Clr.Methods;
+
+/// <summary>
+/// Based on II.25.4.6 Exception handling clauses
+/// </summary>
+public enum CorILExceptionClauses : ushort
+{
+    Exception = 0x0,
+    Filter = 0x1,
+    Finally = 0x2,
+    Fault = 0x4
+}

--- a/Reemit.Decompiler.Clr/Methods/CorILExceptionClauses.cs
+++ b/Reemit.Decompiler.Clr/Methods/CorILExceptionClauses.cs
@@ -3,6 +3,7 @@ namespace Reemit.Decompiler.Clr.Methods;
 /// <summary>
 /// Based on II.25.4.6 Exception handling clauses
 /// </summary>
+[Flags]
 public enum CorILExceptionClauses : ushort
 {
     Exception = 0x0,

--- a/Reemit.Decompiler.Clr/Methods/CorILMethodFlags.cs
+++ b/Reemit.Decompiler.Clr/Methods/CorILMethodFlags.cs
@@ -6,8 +6,11 @@ namespace Reemit.Decompiler.Clr.Methods;
 [Flags]
 public enum CorILMethodFlags : byte
 {
-    FatFormat = 0x3,
-    TinyFormat = 0x2,
     MoreSects = 0x8,
     InitLocals = 0x10,
+    
+    /// <summary>
+    /// A mask to be used to extract <see cref="CorILMethodFormat"/> value.
+    /// </summary>
+    FormatMask = 0x3
 }

--- a/Reemit.Decompiler.Clr/Methods/CorILMethodFlags.cs
+++ b/Reemit.Decompiler.Clr/Methods/CorILMethodFlags.cs
@@ -1,0 +1,13 @@
+namespace Reemit.Decompiler.Clr.Methods;
+
+/// <summary>
+/// Based on II.25.4.4 Flags for method headers
+/// </summary>
+[Flags]
+public enum CorILMethodFlags : byte
+{
+    FatFormat = 0x3,
+    TinyFormat = 0x2,
+    MoreSects = 0x8,
+    InitLocals = 0x10,
+}

--- a/Reemit.Decompiler.Clr/Methods/CorILMethodFormat.cs
+++ b/Reemit.Decompiler.Clr/Methods/CorILMethodFormat.cs
@@ -1,0 +1,11 @@
+namespace Reemit.Decompiler.Clr.Methods;
+
+/// <summary>
+/// Contains mutually exclusive flags indicating format of IL method header.
+/// These members are complementary to <see cref="CorILMethodFlags"/> and are based on II.25.4.1 Method header type.
+/// </summary>
+public enum CorILMethodFormat : byte
+{
+    Tiny = 0x2,
+    Fat = 0x3,
+}

--- a/Reemit.Decompiler.Clr/Methods/CorILMethodSectionFlags.cs
+++ b/Reemit.Decompiler.Clr/Methods/CorILMethodSectionFlags.cs
@@ -1,0 +1,13 @@
+namespace Reemit.Decompiler.Clr.Methods;
+
+/// <summary>
+/// Based on method data section flags defined in II.25.4.5 Method data section
+/// </summary>
+[Flags]
+public enum CorILMethodSectionFlags : uint
+{
+    EHTable = 0x1,
+    OptILTable = 0x2,
+    FatFormat = 0x40,
+    MoreSects = 0x80
+}

--- a/Reemit.Decompiler.Clr/Methods/CorILMethodSectionFlags.cs
+++ b/Reemit.Decompiler.Clr/Methods/CorILMethodSectionFlags.cs
@@ -4,7 +4,7 @@ namespace Reemit.Decompiler.Clr.Methods;
 /// Based on method data section flags defined in II.25.4.5 Method data section
 /// </summary>
 [Flags]
-public enum CorILMethodSectionFlags : uint
+public enum CorILMethodSectionFlags : byte
 {
     EHTable = 0x1,
     OptILTable = 0x2,

--- a/Reemit.Decompiler.Clr/Methods/FatExceptionClause.cs
+++ b/Reemit.Decompiler.Clr/Methods/FatExceptionClause.cs
@@ -1,0 +1,25 @@
+namespace Reemit.Decompiler.Clr.Methods;
+
+public class FatExceptionClause(
+    CorILExceptionClauses flags,
+    uint tryOffset,
+    uint tryLength,
+    uint handlerOffset,
+    uint handlerLength,
+    uint classTokenOrFilterOffset)
+{
+    public CorILExceptionClauses Flags { get; } = flags;
+    public uint TryOffset { get; } = tryOffset;
+    public uint TryLength { get; } = tryLength;
+    public uint HandlerOffset { get; } = handlerOffset;
+    public uint HandlerLength { get; } = handlerLength;
+    public uint ClassTokenOrFilterOffset { get; } = classTokenOrFilterOffset;
+
+    public static FatExceptionClause Read(BinaryReader reader) =>
+        new((CorILExceptionClauses)reader.ReadUInt32(),
+            reader.ReadUInt32(),
+            reader.ReadUInt32(),
+            reader.ReadUInt32(),
+            reader.ReadUInt32(),
+            reader.ReadUInt32());
+}

--- a/Reemit.Decompiler.Clr/Methods/FatExceptionHeader.cs
+++ b/Reemit.Decompiler.Clr/Methods/FatExceptionHeader.cs
@@ -1,0 +1,31 @@
+namespace Reemit.Decompiler.Clr.Methods;
+
+public class FatExceptionHeader(
+    CorILMethodSectionFlags kind,
+    uint dataSize,
+    IReadOnlyList<FatExceptionClause> clauses) : IMethodDataSection
+{
+    public CorILMethodSectionFlags Kind { get; } = kind;
+    public uint DataSize { get; } = dataSize;
+    public IReadOnlyList<FatExceptionClause> Clauses { get; } = clauses;
+
+    public static FatExceptionHeader Read(BinaryReader reader)
+    {
+        var kind = (CorILMethodSectionFlags)reader.ReadByte();
+        var dataSize = BitConverter.ToUInt32([..reader.ReadBytes(3), 0]);
+        
+        // From ECMA-335 II.25.4.5
+        const int exceptionClauseSize = 24;
+        const int headerSize = 4;
+
+        var clausesCount = (int)((dataSize - headerSize) / exceptionClauseSize);
+        var clauses = new List<FatExceptionClause>(clausesCount);
+
+        for (var i = 0; i < clausesCount; i++)
+        {
+            clauses.Add(FatExceptionClause.Read(reader));
+        }
+
+        return new FatExceptionHeader(kind, dataSize, clauses);
+    }
+}

--- a/Reemit.Decompiler.Clr/Methods/FatMethodHeader.cs
+++ b/Reemit.Decompiler.Clr/Methods/FatMethodHeader.cs
@@ -1,0 +1,24 @@
+namespace Reemit.Decompiler.Clr.Methods;
+
+public class FatMethodHeader(CorILMethodFlags flags, byte size, ushort maxStack, uint codeSize, uint localVarSigTok)
+    : IMethodHeader
+{
+    public CorILMethodFlags Flags { get; } = flags;
+    public byte Size { get; } = size;
+    public ushort MaxStack { get; } = maxStack;
+    public uint CodeSize { get; } = codeSize;
+    public uint LocalVarSigTok { get; } = localVarSigTok;
+
+    public static FatMethodHeader Read(BinaryReader reader)
+    {
+        var flagsAndSize = reader.ReadUInt16();
+        const int flagsMask = (1 << 12) - 1;
+        var flags = (CorILMethodFlags)(flagsAndSize & flagsMask);
+        var size = (byte)(flagsAndSize >> 12);
+        var maxStack = reader.ReadUInt16();
+        var codeSize = reader.ReadUInt32();
+        var localVarSig = reader.ReadUInt32();
+
+        return new FatMethodHeader(flags, size, maxStack, codeSize, localVarSig);
+    }
+}

--- a/Reemit.Decompiler.Clr/Methods/IMethodDataSection.cs
+++ b/Reemit.Decompiler.Clr/Methods/IMethodDataSection.cs
@@ -1,0 +1,6 @@
+namespace Reemit.Decompiler.Clr.Methods;
+
+public interface IMethodDataSection
+{
+    CorILMethodSectionFlags Kind { get; }
+}

--- a/Reemit.Decompiler.Clr/Methods/IMethodHeader.cs
+++ b/Reemit.Decompiler.Clr/Methods/IMethodHeader.cs
@@ -1,0 +1,6 @@
+namespace Reemit.Decompiler.Clr.Methods;
+
+public interface IMethodHeader
+{
+    uint CodeSize { get; }
+}

--- a/Reemit.Decompiler.Clr/Methods/MethodDataSectionsReader.cs
+++ b/Reemit.Decompiler.Clr/Methods/MethodDataSectionsReader.cs
@@ -1,0 +1,35 @@
+using Reemit.Common;
+
+namespace Reemit.Decompiler.Clr.Methods;
+
+public static class MethodDataSectionsReader
+{
+    public static IEnumerable<IMethodDataSection> ReadMethodDataSections(SharedReader reader)
+    {
+        var hasMore = true;
+        while (hasMore)
+        {
+            var paddingBytes = reader.Offset % 4;
+
+            if (paddingBytes != 0)
+            {
+                reader = reader.CreateDerivedAtRelativeToCurrentOffset((uint)(4 - reader.Offset % 4));
+            }
+
+            // Create a temporary reader to peek first byte.
+            var tempReader = reader.CreateDerivedAtRelativeToCurrentOffset(0);
+            var flags = (CorILMethodSectionFlags)tempReader.ReadByte();
+
+            if (flags.HasFlag(CorILMethodSectionFlags.FatFormat))
+            {
+                yield return FatExceptionHeader.Read(reader);
+            }
+            else
+            {
+                yield return SmallExceptionHeader.Read(reader);
+            }
+
+            hasMore = flags.HasFlag(CorILMethodSectionFlags.MoreSects);
+        }
+    }
+}

--- a/Reemit.Decompiler.Clr/Methods/MethodDataSectionsReader.cs
+++ b/Reemit.Decompiler.Clr/Methods/MethodDataSectionsReader.cs
@@ -13,7 +13,7 @@ public static class MethodDataSectionsReader
 
             if (paddingBytes != 0)
             {
-                reader = reader.CreateDerivedAtRelativeToCurrentOffset((uint)(4 - reader.Offset % 4));
+                reader = reader.CreateDerivedAtRelativeToCurrentOffset((uint)(4 - paddingBytes));
             }
 
             // Create a temporary reader to peek first byte.

--- a/Reemit.Decompiler.Clr/Methods/MethodHeaderReader.cs
+++ b/Reemit.Decompiler.Clr/Methods/MethodHeaderReader.cs
@@ -9,14 +9,14 @@ public static class MethodHeaderReader
         var tempReader = reader.CreateDerivedAtRelativeToCurrentOffset(0);
         var signatureByte = tempReader.ReadByte();
 
-        var twoLeastSignificantBits = (uint)(signatureByte & 0b11);
+        var format = (CorILMethodFormat)(signatureByte & (byte)CorILMethodFlags.FormatMask);
 
-        return twoLeastSignificantBits switch
+        return format switch
         {
-            (uint)CorILMethodFlags.TinyFormat => TinyMethodHeader.Read(reader),
-            (uint)CorILMethodFlags.FatFormat => FatMethodHeader.Read(reader),
+            CorILMethodFormat.Tiny => TinyMethodHeader.Read(reader),
+            CorILMethodFormat.Fat => FatMethodHeader.Read(reader),
             _ => throw new BadImageFormatException(
-                $"Unrecognized method header (signature: {twoLeastSignificantBits:X})")
+                $"Unrecognized method header (signature: 0x{format:X})")
         };
     }
 }

--- a/Reemit.Decompiler.Clr/Methods/MethodHeaderReader.cs
+++ b/Reemit.Decompiler.Clr/Methods/MethodHeaderReader.cs
@@ -1,0 +1,22 @@
+using Reemit.Common;
+
+namespace Reemit.Decompiler.Clr.Methods;
+
+public static class MethodHeaderReader
+{
+    public static IMethodHeader ReadMethodHeader(SharedReader reader)
+    {
+        var tempReader = reader.CreateDerivedAtRelativeToCurrentOffset(0);
+        var signatureByte = tempReader.ReadByte();
+
+        var twoLeastSignificantBits = (uint)(signatureByte & 0b11);
+
+        return twoLeastSignificantBits switch
+        {
+            (uint)CorILMethodFlags.TinyFormat => TinyMethodHeader.Read(reader),
+            (uint)CorILMethodFlags.FatFormat => FatMethodHeader.Read(reader),
+            _ => throw new BadImageFormatException(
+                $"Unrecognized method header (signature: {twoLeastSignificantBits:X})")
+        };
+    }
+}

--- a/Reemit.Decompiler.Clr/Methods/SmallExceptionClause.cs
+++ b/Reemit.Decompiler.Clr/Methods/SmallExceptionClause.cs
@@ -1,0 +1,25 @@
+namespace Reemit.Decompiler.Clr.Methods;
+
+public class SmallExceptionClause(
+    CorILExceptionClauses flags,
+    ushort tryOffset,
+    byte tryLength,
+    ushort handlerOffset,
+    byte handlerLength,
+    uint classTokenOrFilterOffset)
+{
+    public CorILExceptionClauses Flags { get; } = flags;
+    public ushort TryOffset { get; } = tryOffset;
+    public byte TryLength { get; } = tryLength;
+    public ushort HandlerOffset { get; } = handlerOffset;
+    public byte HandlerLength { get; } = handlerLength;
+    public uint ClassTokenOrFilterOffset { get; } = classTokenOrFilterOffset;
+
+    public static SmallExceptionClause Read(BinaryReader reader) =>
+        new((CorILExceptionClauses)reader.ReadUInt16(),
+            reader.ReadUInt16(),
+            reader.ReadByte(),
+            reader.ReadUInt16(),
+            reader.ReadByte(),
+            reader.ReadUInt32());
+}

--- a/Reemit.Decompiler.Clr/Methods/SmallExceptionHeader.cs
+++ b/Reemit.Decompiler.Clr/Methods/SmallExceptionHeader.cs
@@ -1,0 +1,39 @@
+namespace Reemit.Decompiler.Clr.Methods;
+
+public class SmallExceptionHeader(
+    CorILMethodSectionFlags kind,
+    byte dataSize,
+    ushort reserved,
+    IReadOnlyList<SmallExceptionClause> clauses) : IMethodDataSection
+{
+    public CorILMethodSectionFlags Kind { get; } = kind;
+    public byte DataSize { get; } = dataSize;
+    public ushort Reserved { get; } = reserved;
+    public IReadOnlyList<SmallExceptionClause> Clauses { get; } = clauses;
+
+    public static SmallExceptionHeader Read(BinaryReader reader)
+    {
+        var kind = (CorILMethodSectionFlags)reader.ReadByte();
+        var dataSize = reader.ReadByte();
+        var reserved = reader.ReadUInt16();
+
+        if (reserved != 0)
+        {
+            throw new BadImageFormatException("Padding should always be 0");
+        }
+
+        // From ECMA-335 II.25.4.5
+        const int exceptionClauseSize = 12;
+        const int headerSize = 4;
+
+        var clausesCount = (dataSize - headerSize) / exceptionClauseSize;
+        var clauses = new List<SmallExceptionClause>(clausesCount);
+
+        for (var i = 0; i < clausesCount; i++)
+        {
+            clauses.Add(SmallExceptionClause.Read(reader));
+        }
+
+        return new SmallExceptionHeader(kind, dataSize, reserved, clauses);
+    }
+}

--- a/Reemit.Decompiler.Clr/Methods/TinyMethodHeader.cs
+++ b/Reemit.Decompiler.Clr/Methods/TinyMethodHeader.cs
@@ -1,0 +1,9 @@
+    namespace Reemit.Decompiler.Clr.Methods;
+
+public class TinyMethodHeader(uint codeSize) : IMethodHeader
+{
+    public uint CodeSize { get; } = codeSize;
+
+    public static TinyMethodHeader Read(BinaryReader reader) =>
+        new((uint)(reader.ReadByte() & ~((1 << 2) - 1)));
+}

--- a/Reemit.Decompiler.Clr/Methods/TinyMethodHeader.cs
+++ b/Reemit.Decompiler.Clr/Methods/TinyMethodHeader.cs
@@ -5,5 +5,5 @@ public class TinyMethodHeader(uint codeSize) : IMethodHeader
     public uint CodeSize { get; } = codeSize;
 
     public static TinyMethodHeader Read(BinaryReader reader) =>
-        new((uint)(reader.ReadByte() & ~((1 << 2) - 1)));
+        new((uint)((reader.ReadByte() & ~0x3) >> 2));
 }

--- a/Reemit.Decompiler/ClrMetadataContext.cs
+++ b/Reemit.Decompiler/ClrMetadataContext.cs
@@ -1,9 +1,0 @@
-using Reemit.Decompiler.Clr.Metadata.Streams;
-
-namespace Reemit.Decompiler;
-
-public class ClrMetadataContext(MetadataTablesStream metadataTablesStream, StringsHeapStream stringsHeapStream)
-{
-    public MetadataTablesStream MetadataTablesStream { get; } = metadataTablesStream;
-    public StringsHeapStream StringsHeapStream { get; } = stringsHeapStream;
-}

--- a/Reemit.Decompiler/ClrMethod.cs
+++ b/Reemit.Decompiler/ClrMethod.cs
@@ -21,9 +21,7 @@ public class ClrMethod(
 
         var methodHeader = MethodHeaderReader.ReadMethodHeader(corILMethodReader);
 
-        byte[] methodBody = [];//corILMethodReader.ReadBytes((int)methodHeader.CodeSize);
-        
-        corILMethodReader = corILMethodReader.CreateDerivedAtRelativeToCurrentOffset(methodHeader.CodeSize);
+        var methodBody = corILMethodReader.ReadBytes((int)methodHeader.CodeSize);
 
         if (methodHeader is FatMethodHeader fatMethodHeader)
         {

--- a/Reemit.Decompiler/ClrMethod.cs
+++ b/Reemit.Decompiler/ClrMethod.cs
@@ -15,7 +15,13 @@ public class ClrMethod(
     public static ClrMethod FromMethodDefRow(MethodDefRow methodDefRow, ModuleReaderContext context)
     {
         var name = context.StringsHeapStream.Read(methodDefRow.Name);
-        if (methodDefRow.Rva == 0) return new ClrMethod(name, 0, []);
+        
+        // TODO: Investigate what exactly it means when a MethodDef row has its RVA set to 0
+        if (methodDefRow.Rva == 0)
+        {
+            return new ClrMethod(name, 0, []);
+        }
+
         var corILMethodOffset = context.PEFile.GetFileOffset(methodDefRow.Rva);
         var corILMethodReader = context.PEFile.CreateReaderAt(corILMethodOffset);
 

--- a/Reemit.Decompiler/ClrMethod.cs
+++ b/Reemit.Decompiler/ClrMethod.cs
@@ -1,0 +1,44 @@
+using Reemit.Decompiler.Clr.Metadata.Tables;
+using Reemit.Decompiler.Clr.Methods;
+
+namespace Reemit.Decompiler;
+
+public class ClrMethod(
+    string name,
+    int maxStack,
+    byte[] methodBody)
+{
+    public string Name { get; } = name;
+    public int MaxStack { get; } = maxStack;
+    public byte[] MethodBody { get; } = methodBody;
+
+    public static ClrMethod FromMethodDefRow(MethodDefRow methodDefRow, ModuleReaderContext context)
+    {
+        var name = context.StringsHeapStream.Read(methodDefRow.Name);
+        if (methodDefRow.Rva == 0) return new ClrMethod(name, 0, []);
+        var corILMethodOffset = context.PEFile.GetFileOffset(methodDefRow.Rva);
+        var corILMethodReader = context.PEFile.CreateReaderAt(corILMethodOffset);
+
+        var methodHeader = MethodHeaderReader.ReadMethodHeader(corILMethodReader);
+
+        byte[] methodBody = [];//corILMethodReader.ReadBytes((int)methodHeader.CodeSize);
+        
+        corILMethodReader = corILMethodReader.CreateDerivedAtRelativeToCurrentOffset(methodHeader.CodeSize);
+
+        if (methodHeader is FatMethodHeader fatMethodHeader)
+        {
+            if (fatMethodHeader.Flags.HasFlag(CorILMethodFlags.MoreSects))
+            {
+                MethodDataSectionsReader.ReadMethodDataSections(corILMethodReader).ToArray();
+            }
+        }
+
+        var maxStack = methodHeader is TinyMethodHeader
+            // From ECMA-335 II.25.4:
+            // A method is given a tiny header if it has no local variables, maxstack is 8 or less, 
+            ? (ushort)8
+            : ((FatMethodHeader)methodHeader).MaxStack;
+
+        return new ClrMethod(name, maxStack, methodBody);
+    }
+}

--- a/Reemit.Decompiler/ClrModule.cs
+++ b/Reemit.Decompiler/ClrModule.cs
@@ -1,4 +1,4 @@
-﻿﻿using Reemit.Decompiler.Clr.Metadata;
+﻿using Reemit.Decompiler.Clr.Metadata;
 using Reemit.Decompiler.Clr.Metadata.Streams;
 using Reemit.Decompiler.PE;
 
@@ -48,7 +48,8 @@ public class ClrModule
         var metadataStreamOffset = metadataOffset + metadataStreamHeader.Offset;
         var metadataStream = new MetadataTablesStream(peFile.CreateReaderAt(metadataStreamOffset));
 
-        var context = new ClrMetadataContext(metadataStream, stringsStream);
+        var context = new ModuleReaderContext(peFile, metadataStream, stringsStream,
+            new TableReferenceResolver(metadataStream.Rows));
 
         var types = metadataStream.TypeDef?.Rows.Select(x => ClrType.FromTypeDefRow(x, context)).ToArray().AsReadOnly();
 

--- a/Reemit.Decompiler/ModuleReaderContext.cs
+++ b/Reemit.Decompiler/ModuleReaderContext.cs
@@ -1,0 +1,11 @@
+using Reemit.Decompiler.Clr.Metadata;
+using Reemit.Decompiler.Clr.Metadata.Streams;
+using Reemit.Decompiler.PE;
+
+namespace Reemit.Decompiler;
+
+public record ModuleReaderContext(
+    PEFile PEFile,
+    MetadataTablesStream MetadataTablesStream,
+    StringsHeapStream StringsHeapStream,
+    TableReferenceResolver TableReferenceResolver);


### PR DESCRIPTION
This adds implementation of reading all structs that are part of the COR_ILMETHOD struct defined in ECMA-335: "II.25.4 Common Intermediate Language physical layout".

Type hierarchy of metadata table rows was significantly changed. `IMetadataRecord` interface and `MetadataRecord` abstract class were introduced. This was done to make `TableReferenceResolver` able to return a list of table rows as list of types implementing an interface. Unfortunately, C# does not allow to return a list of interface implementing objects if the interface has abstract static members.

`TableReferenceResolver` requires a dictionary of all metadata tables and their rows. `MetadataTablesStream` builds such dictionary when reading tables.

My benchmarking and experiments show that method decompilation can take a while. For this reason, we should create a means of lock-free module reading (#18) and perhaps in the future parallelize decompilation.

Please note that this PR does not include showing methods in Module Explorer Tree. This feature is tracked in #19.