### PR TITLE
Fix TableReferenceResolver returning incorrect rows

### DIFF
--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/TableReferenceResolverTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/TableReferenceResolverTests.cs
@@ -38,7 +38,7 @@ public class TableReferenceResolverTests
         // Act
         var result = tableReferenceResolver.GetReferencedRows<ReferencingRecord, ReferencedRecord>(
             referencingRecords[0],
-            x => x.ReferencedTableRid);
+            x => x.ReferencedRowRid);
 
         // Assert
         Assert.Equal(referencedRecords[..3], result);
@@ -78,13 +78,49 @@ public class TableReferenceResolverTests
         // Act
         var result = tableReferenceResolver.GetReferencedRows<ReferencingRecord, ReferencedRecord>(
             referencingRecords[1],
-            x => x.ReferencedTableRid);
+            x => x.ReferencedRowRid);
 
         // Assert
         Assert.Equal(referencedRecords[3..], result);
     }
+    
+    [Fact]
+    public void GetReferencedRows_RecordReferencingSameRowAsNextRow_ReturnsEmptyCollection()
+    {
+        // Arrange
+        ReferencingRecord[] referencingRecords =
+        [
+            new ReferencingRecord(1, 1),
+            new ReferencingRecord(2, 1)
+        ];
 
-    private record ReferencingRecord(uint Rid, uint ReferencedTableRid) : IMetadataTableRow<ReferencingRecord>
+        ReferencedRecord[] referencedRecords =
+        [
+            new ReferencedRecord(1),
+            new ReferencedRecord(2)
+        ];
+
+        IrrelevantRecord[] irrelevantRecords = [new IrrelevantRecord(1), new IrrelevantRecord(2)];
+
+        var allTables = new Dictionary<MetadataTableName, IReadOnlyList<IMetadataRecord>>
+        {
+            { ReferencingRecord.TableName, referencingRecords },
+            { ReferencedRecord.TableName, referencedRecords },
+            { IrrelevantRecord.TableName, irrelevantRecords }
+        };
+
+        var tableReferenceResolver = new TableReferenceResolver(allTables);
+
+        // Act
+        var result = tableReferenceResolver.GetReferencedRows<ReferencingRecord, ReferencedRecord>(
+            referencingRecords[0],
+            x => x.ReferencedRowRid);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    private record ReferencingRecord(uint Rid, uint ReferencedRowRid) : IMetadataTableRow<ReferencingRecord>
     {
         public static ReferencingRecord Read(uint rid, MetadataTableDataReader reader) =>
             throw new NotImplementedException();

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/TableReferenceResolverTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/TableReferenceResolverTests.cs
@@ -1,0 +1,110 @@
+using Reemit.Decompiler.Clr.Metadata;
+using Reemit.Decompiler.Clr.Metadata.Tables;
+
+namespace Reemit.Decompiler.Clr.UnitTests.Metadata;
+
+public class TableReferenceResolverTests
+{
+    [Fact]
+    public void GetReferencedRows_RecordReferencingContiguousRunOfRecordsUntilNextRowRun_ReturnsRunOfRecords()
+    {
+        // Arrange
+        ReferencingRecord[] referencingRecords =
+        [
+            new ReferencingRecord(1, 1),
+            new ReferencingRecord(2, 4)
+        ];
+
+        ReferencedRecord[] referencedRecords =
+        [
+            new ReferencedRecord(1),
+            new ReferencedRecord(2),
+            new ReferencedRecord(3),
+            new ReferencedRecord(4),
+            new ReferencedRecord(5),
+        ];
+
+        IrrelevantRecord[] irrelevantRecords = [new IrrelevantRecord(1), new IrrelevantRecord(2)];
+
+        var allTables = new Dictionary<MetadataTableName, IReadOnlyList<IMetadataRecord>>
+        {
+            { ReferencingRecord.TableName, referencingRecords },
+            { ReferencedRecord.TableName, referencedRecords },
+            { IrrelevantRecord.TableName, irrelevantRecords }
+        };
+
+        var tableReferenceResolver = new TableReferenceResolver(allTables);
+
+        // Act
+        var result = tableReferenceResolver.GetReferencedRows<ReferencingRecord, ReferencedRecord>(
+            referencingRecords[0],
+            x => x.ReferencedTableRid);
+
+        // Assert
+        Assert.Equal(referencedRecords[..3], result);
+    }
+
+    [Fact]
+    public void
+        GetReferencedRows_RecordReferencingContiguousRunOfRecordsUntilEndOfTable_ReturnsRunOfRecordsUntilEndOfTable()
+    {
+        // Arrange
+        ReferencingRecord[] referencingRecords =
+        [
+            new ReferencingRecord(1, 1),
+            new ReferencingRecord(2, 4)
+        ];
+
+        ReferencedRecord[] referencedRecords =
+        [
+            new ReferencedRecord(1),
+            new ReferencedRecord(2),
+            new ReferencedRecord(3),
+            new ReferencedRecord(4),
+            new ReferencedRecord(5),
+        ];
+
+        IrrelevantRecord[] irrelevantRecords = [new IrrelevantRecord(1), new IrrelevantRecord(2)];
+
+        var allTables = new Dictionary<MetadataTableName, IReadOnlyList<IMetadataRecord>>
+        {
+            { ReferencingRecord.TableName, referencingRecords },
+            { ReferencedRecord.TableName, referencedRecords },
+            { IrrelevantRecord.TableName, irrelevantRecords }
+        };
+
+        var tableReferenceResolver = new TableReferenceResolver(allTables);
+
+        // Act
+        var result = tableReferenceResolver.GetReferencedRows<ReferencingRecord, ReferencedRecord>(
+            referencingRecords[1],
+            x => x.ReferencedTableRid);
+
+        // Assert
+        Assert.Equal(referencedRecords[3..], result);
+    }
+
+    private record ReferencingRecord(uint Rid, uint ReferencedTableRid) : IMetadataTableRow<ReferencingRecord>
+    {
+        public static ReferencingRecord Read(uint rid, MetadataTableDataReader reader) =>
+            throw new NotImplementedException();
+
+        public static MetadataTableName TableName => MetadataTableName.File;
+    }
+
+    private record ReferencedRecord(uint Rid) : IMetadataTableRow<ReferencedRecord>
+    {
+        public static ReferencedRecord Read(uint rid, MetadataTableDataReader reader) =>
+            throw new NotImplementedException();
+
+        public static MetadataTableName TableName => MetadataTableName.Assembly;
+    }
+
+    private record IrrelevantRecord(uint Rid) : IMetadataTableRow<IrrelevantRecord>
+    {
+        public static IrrelevantRecord Read(uint rid, MetadataTableDataReader reader) =>
+            throw new NotImplementedException();
+
+        public static MetadataTableName TableName => MetadataTableName.Param;
+    }
+}

--- a/Reemit.Decompiler.Clr/Metadata/TableReferenceResolver.cs
+++ b/Reemit.Decompiler.Clr/Metadata/TableReferenceResolver.cs
@@ -4,15 +4,11 @@ namespace Reemit.Decompiler.Clr.Metadata;
 
 public class TableReferenceResolver(IReadOnlyDictionary<MetadataTableName, IReadOnlyList<IMetadataRecord>> allTables)
 {
-    public IReadOnlyList<IMetadataRecord>
-        GetReferencedRows<TRef>(CodedIndex codedIndex, TRef referencingRow)
-        where TRef : IMetadataTableRow =>
-        codedIndex.GetReferencedRows(referencingRow, allTables);
-
-    public IReadOnlyList<TTarget> GetReferencedRows<TRef, TTarget>(TRef referencingRow)
+    public IReadOnlyList<TTarget> GetReferencedRows<TRef, TTarget>(TRef referencingRow, Func<TRef, uint> ridSelector)
         where TRef : IMetadataTableRow
         where TTarget : IMetadataTableRow =>
-        CodedIndexExtensions.GetReferencedRows(referencingRow, allTables[TRef.TableName],
+        CodedIndexExtensions.GetReferencedRows(referencingRow, ridSelector,
+                allTables[TRef.TableName].OfType<TRef>().ToArray(),
                 allTables[TTarget.TableName])
             .Cast<TTarget>()
             .ToArray()
@@ -21,13 +17,9 @@ public class TableReferenceResolver(IReadOnlyDictionary<MetadataTableName, IRead
 
 public static class CodedIndexExtensions
 {
-    public static IReadOnlyList<IMetadataRecord> GetReferencedRows<TRef>(this CodedIndex codedIndex,
+    public static IReadOnlyList<TTarget> GetReferencedRows<TRef, TTarget>(
         TRef referencingRow,
-        IReadOnlyDictionary<MetadataTableName, IReadOnlyList<IMetadataRecord>> allTables)
-        where TRef : IMetadataTableRow =>
-        GetReferencedRows(referencingRow, allTables[TRef.TableName], allTables[codedIndex.ReferencedTable]);
-
-    public static IReadOnlyList<TTarget> GetReferencedRows<TRef, TTarget>(TRef referencingRow,
+        Func<TRef, uint> ridSelector,
         IReadOnlyList<TRef> referencingTableRows,
         IReadOnlyList<TTarget> referencedTableRows)
         where TRef : IMetadataRecord
@@ -35,12 +27,30 @@ public static class CodedIndexExtensions
     {
         var nextRowInReferencingTable = referencingTableRows.SingleOrDefault(x => x.Rid - referencingRow.Rid == 1);
 
-        var firstRowIndex = (int)(referencingRow.Rid - 1);
-        var lastRowIndex = (int?)(nextRowInReferencingTable?.Rid - 1) ?? referencedTableRows.Count - 1;
+        var firstRowReferencedRid = ridSelector(referencingRow);
+
+        int lastReferencedRowIndex;
+
+        if (nextRowInReferencingTable is not null)
+        {
+            var nextRowReferencedRid = ridSelector(nextRowInReferencingTable);
+            if (firstRowReferencedRid == nextRowReferencedRid)
+            {
+                return Array.Empty<TTarget>();
+            }
+
+            lastReferencedRowIndex = (int)ridSelector(nextRowInReferencingTable) - 1;
+        }
+        else
+        {
+            lastReferencedRowIndex = referencedTableRows.Count;
+        }
+        
+        var firstReferencedRowIndex = (int)firstRowReferencedRid - 1;
 
         return referencedTableRows
-            .Skip(firstRowIndex)
-            .Take(lastRowIndex)
+            .Skip(firstReferencedRowIndex)
+            .Take(lastReferencedRowIndex - firstReferencedRowIndex)
             .ToArray()
             .AsReadOnly();
     }

--- a/Reemit.Decompiler.Clr/Metadata/TableReferenceResolver.cs
+++ b/Reemit.Decompiler.Clr/Metadata/TableReferenceResolver.cs
@@ -29,7 +29,7 @@ public static class CodedIndexExtensions
 
         var firstRowReferencedRid = ridSelector(referencingRow);
 
-        int lastReferencedRowIndex;
+        int lastReferencedRowNo;
 
         if (nextRowInReferencingTable is not null)
         {
@@ -39,18 +39,18 @@ public static class CodedIndexExtensions
                 return Array.Empty<TTarget>();
             }
 
-            lastReferencedRowIndex = (int)ridSelector(nextRowInReferencingTable) - 1;
+            lastReferencedRowNo = (int)ridSelector(nextRowInReferencingTable) - 1;
         }
         else
         {
-            lastReferencedRowIndex = referencedTableRows.Count;
+            lastReferencedRowNo = referencedTableRows.Count;
         }
         
         var firstReferencedRowIndex = (int)firstRowReferencedRid - 1;
 
         return referencedTableRows
             .Skip(firstReferencedRowIndex)
-            .Take(lastReferencedRowIndex - firstReferencedRowIndex)
+            .Take(lastReferencedRowNo - firstReferencedRowIndex)
             .ToArray()
             .AsReadOnly();
     }

--- a/Reemit.Decompiler/ClrType.cs
+++ b/Reemit.Decompiler/ClrType.cs
@@ -74,14 +74,14 @@ public class ClrType
             isValueType,
             stringsHeap.ReadMapped(typeDefRow.TypeName),
             stringsHeap.Read(typeDefRow.TypeNamespace),
-            new Lazy<IReadOnlyList<ClrMethod>>(GetMethods)
+            GetMethods()
         );
 
         return type;
 
         IReadOnlyList<ClrMethod> GetMethods()
         {
-            var methods = context.TableReferenceResolver.GetReferencedRows<TypeDefRow, MethodDefRow>(typeDefRow);
+            var methods = context.TableReferenceResolver.GetReferencedRows<TypeDefRow, MethodDefRow>(typeDefRow, x => x.MethodList);
             return methods.Select(m => ClrMethod.FromMethodDefRow(m, context)).ToArray().AsReadOnly();
         }
     }

--- a/Reemit.Decompiler/ClrType.cs
+++ b/Reemit.Decompiler/ClrType.cs
@@ -74,7 +74,7 @@ public class ClrType
             isValueType,
             stringsHeap.ReadMapped(typeDefRow.TypeName),
             stringsHeap.Read(typeDefRow.TypeNamespace),
-            GetMethods()
+            new Lazy<IReadOnlyList<ClrMethod>>(GetMethods)
         );
 
         return type;


### PR DESCRIPTION
This PR fixes the issue where TableReferenceResolver would return incorrect rows. TableReferenceResolver is now covered by unit tests to avoid such issues in the future.

Additionally, methods for resolving contiguous runs of rows referenced by a CodedIndex property were removed, as there were no such cases mentioned in the specification.