### PR TITLE
Removed SharedReader TLS and locking

### DIFF
--- a/Reemit.Common.UnitTests/SharedReaderScopeTests.cs
+++ b/Reemit.Common.UnitTests/SharedReaderScopeTests.cs
@@ -10,7 +10,7 @@ public sealed class SharedReaderScopeTests
         using var stream = new MemoryStream(bytes);
         using var binaryReader = new BinaryReader(stream);
         const int sharedReaderOffset = 1;
-        using var sharedReader = new SharedReader(sharedReaderOffset, binaryReader, new object());
+        using var sharedReader = new SharedReader(sharedReaderOffset, binaryReader);
         const int readBytesCount = 2;
         byte[] actualBytes;
         RangeMapped<byte[]> actualRangeMappedBytes;
@@ -41,7 +41,7 @@ public sealed class SharedReaderScopeTests
         using var stream = new MemoryStream(bytes);
         using var binaryReader = new BinaryReader(stream);
         const int sharedReaderOffset = 1;
-        using var sharedReader = new SharedReader(sharedReaderOffset, binaryReader, new object());
+        using var sharedReader = new SharedReader(sharedReaderOffset, binaryReader);
         const int readBytesCount = 2;
         byte[] actualOuterBytes = new byte[readBytesCount];
         RangeMapped<byte[]> actualInnerBytes, actualRangeMappedOuterBytes, actualRangeMappedInnerBytes;

--- a/Reemit.Common.UnitTests/SharedReaderTests.cs
+++ b/Reemit.Common.UnitTests/SharedReaderTests.cs
@@ -14,7 +14,7 @@ public sealed class SharedReaderTests
         using var stream = new MemoryStream(bytes);
         using var binaryReader = new BinaryReader(stream);
         const int sharedReaderOffset = 1;
-        using var sharedReader = new SharedReader(sharedReaderOffset, binaryReader, new object());
+        using var sharedReader = new SharedReader(sharedReaderOffset, binaryReader);
         const int readBytesCount = 2;
         
         // Act
@@ -35,7 +35,7 @@ public sealed class SharedReaderTests
         using var stream = new MemoryStream(bytes);
         using var binaryReader = new BinaryReader(stream);
         const int sharedReaderOffset = 1;
-        using var sharedReader = new SharedReader(sharedReaderOffset, binaryReader, new object());
+        using var sharedReader = new SharedReader(sharedReaderOffset, binaryReader);
         const int readBytesCount = 0x100;
 
         // Act
@@ -80,7 +80,7 @@ public sealed class SharedReaderTests
 
         using var stream = new MemoryStream(bytes);
         using var binaryReader = new BinaryReader(stream);
-        using var sharedReader = new SharedReader(sharedReaderOffset, binaryReader, new object());
+        using var sharedReader = new SharedReader(sharedReaderOffset, binaryReader);
         var actualUnmanagedValues = new T[expectedUnmanagedValues.Length];
         var isRangeMapped = false;
         var expectedPositions = new int[expectedUnmanagedValues.Length];
@@ -184,7 +184,7 @@ public sealed class SharedReaderTests
         // Arrange
         using var stream = new MemoryStream();
         using var binaryReader = new BinaryReader(stream);
-        using var sharedReader = new SharedReader(0, binaryReader, new object());
+        using var sharedReader = new SharedReader(0, binaryReader);
 
         // Act
         var act = () => readAction(sharedReader);
@@ -212,29 +212,13 @@ public sealed class SharedReaderTests
     private static object[] CreateNotImplementedTestCase(Action<SharedReader> readAction) => [readAction];
 
     [Fact]
-    public void SynchronizationObject_Get_EqualsConstructorArgument()
-    {
-        // Arrange
-        using var stream = new MemoryStream();
-        using var binaryReader = new BinaryReader(stream);
-        var syncObject = new object();
-        using var sharedReader = new SharedReader(1, binaryReader, syncObject);
-
-        // Act
-        var actualSyncObject = sharedReader.SynchronizationObject;
-
-        // Assert
-        Assert.Equal(syncObject, actualSyncObject);
-    }
-
-    [Fact]
     public void CreateDerivedAtRelativeToStartOffset_Called_RelativeToStartOffsetSet()
     {
         // Arrange
         using var stream = new MemoryStream();
         using var binaryReader = new BinaryReader(stream);
         const int sharedReaderOffset = 1;
-        using var sharedReader = new SharedReader(sharedReaderOffset, binaryReader, new object());
+        using var sharedReader = new SharedReader(sharedReaderOffset, binaryReader);
         const int derivedSharedReaderOffset = 2;
 
         // Act
@@ -255,7 +239,7 @@ public sealed class SharedReaderTests
         using var stream = new MemoryStream(bytes);
         using var binaryReader = new BinaryReader(stream);
         const int sharedReaderOffset = 1;
-        using var sharedReader = new SharedReader(sharedReaderOffset, binaryReader, new object());
+        using var sharedReader = new SharedReader(sharedReaderOffset, binaryReader);
         sharedReader.ReadByte();
         const int readDataSize = sizeof(byte);
         const int derivedSharedReaderOffset = 2;

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/FatExceptionClauseTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/FatExceptionClauseTests.cs
@@ -33,7 +33,7 @@ public class FatExceptionClauseTests
         using var reader = new BinaryReader(memoryStream);
 
         // Act
-        var clause = FatExceptionClause.Read(new SharedReader(0, reader, new object()));
+        var clause = FatExceptionClause.Read(new SharedReader(0, reader));
         
         // Assert
         Assert.Equal(CorILExceptionClauses.Exception, clause.Flags);

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/FatExceptionHeaderTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/FatExceptionHeaderTests.cs
@@ -25,7 +25,7 @@ public class FatExceptionHeaderTests
         using var reader = new BinaryReader(memoryStream);
         
         // Act
-        var header = FatExceptionHeader.Read(new SharedReader(0, reader, new object()));
+        var header = FatExceptionHeader.Read(new SharedReader(0, reader));
         
         // Assert
         Assert.Equal(CorILMethodSectionFlags.EHTable | CorILMethodSectionFlags.FatFormat, header.Kind);

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/FatMethodHeaderTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/FatMethodHeaderTests.cs
@@ -28,7 +28,7 @@ public class FatMethodHeaderTests
 
         // Act
         var header =
-            FatMethodHeader.Read(new SharedReader(0, reader, new object()));
+            FatMethodHeader.Read(new SharedReader(0, reader));
 
         // Assert
         Assert.True(header.Flags.HasFlag(CorILMethodFlags.InitLocals));

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/MethodDataSectionsReaderTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/MethodDataSectionsReaderTests.cs
@@ -32,7 +32,7 @@ public class MethodDataSectionsReaderTests
         using var reader = new BinaryReader(memoryStream);
 
         // Act
-        var sections = MethodDataSectionsReader.ReadMethodDataSections(new SharedReader(2, reader, new object()))
+        var sections = MethodDataSectionsReader.ReadMethodDataSections(new SharedReader(2, reader))
             .ToArray();
 
         // Assert

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/MethodHeaderReaderTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/MethodHeaderReaderTests.cs
@@ -23,7 +23,7 @@ public class MethodHeaderReaderTests
         using var reader = new BinaryReader(memoryStream);
 
         // Act
-        var header = MethodHeaderReader.ReadMethodHeader(new SharedReader(0, reader, new object()));
+        var header = MethodHeaderReader.ReadMethodHeader(new SharedReader(0, reader));
 
         // Assert
         Assert.IsType<TinyMethodHeader>(header);
@@ -50,7 +50,7 @@ public class MethodHeaderReaderTests
         using var reader = new BinaryReader(memoryStream);
 
         // Act
-        var header = MethodHeaderReader.ReadMethodHeader(new SharedReader(0, reader, new object()));
+        var header = MethodHeaderReader.ReadMethodHeader(new SharedReader(0, reader));
 
         // Assert
         Assert.IsType<FatMethodHeader>(header);

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/SmallExceptionClauseTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/SmallExceptionClauseTests.cs
@@ -33,7 +33,7 @@ public class SmallExceptionClauseTests
         using var reader = new BinaryReader(memoryStream);
 
         // Act
-        var clause = SmallExceptionClause.Read(new SharedReader(0, reader, new object()));
+        var clause = SmallExceptionClause.Read(new SharedReader(0, reader));
         
         // Assert
         Assert.Equal(CorILExceptionClauses.Exception, clause.Flags);

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/SmallExceptionHeaderTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/SmallExceptionHeaderTests.cs
@@ -29,7 +29,7 @@ public class SmallExceptionHeaderTests
         using var reader = new BinaryReader(memoryStream);
 
         // Act
-        var header = SmallExceptionHeader.Read(new SharedReader(0, reader, new object()));
+        var header = SmallExceptionHeader.Read(new SharedReader(0, reader));
 
         // Assert
         Assert.Equal(CorILMethodSectionFlags.EHTable, header.Kind);

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/TinyMethodHeaderTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Methods/TinyMethodHeaderTests.cs
@@ -23,7 +23,7 @@ public class TinyMethodHeaderTests
         using var reader = new BinaryReader(memoryStream);
 
         // Act
-        var header = TinyMethodHeader.Read(new SharedReader(0, reader, new object()));
+        var header = TinyMethodHeader.Read(new SharedReader(0, reader));
         
         // Assert
         Assert.Equal(8u, header.CodeSize);

--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Streams/MetadataTablesStreamTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Streams/MetadataTablesStreamTests.cs
@@ -12,7 +12,7 @@ public class MetadataTablesStreamTests
         // Arrange
         await using var fileStream = File.OpenRead("Resources/metadatatablesstream.bin");
         using var reader = new BinaryReader(fileStream);
-        using var sharedReader = new SharedReader(0, reader, new());
+        using var sharedReader = new SharedReader(0, reader);
 
         // Act
         var header = new MetadataTablesStream(sharedReader);

--- a/Reemit.Decompiler.Clr/Metadata/Tables/MetadataTableRowReader.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/MetadataTableRowReader.cs
@@ -6,8 +6,7 @@ public class MetadataTableDataReader(
     BinaryReader reader,
     HeapSizes heapSizes,
     IReadOnlyDictionary<MetadataTableName, uint> rowsCounts) : SharedReader(
-    (reader as SharedReader)?.Offset ?? (int)reader.BaseStream.Position, reader,
-    (reader as SharedReader)?.SynchronizationObject ?? new object())
+    (reader as SharedReader)?.Offset ?? (int)reader.BaseStream.Position, reader)
 {
     public uint ReadStringRid() => ReadRid(HeapSizes.StringStream);
 


### PR DESCRIPTION
This PR removes `ThreadLocal<T>` usage from `SharedReader`, as well as the internal and external locks used to synchronize usage of the type. This was done for a few reasons:

1) The TLS usage of `SharedReader` was much slower than I expected. It was also inherently broken given that asynchronous tasks from different contexts can be scheduled on the same thread. `AsyncLocal<T>` would have been a better choice, but would still have problems in fringe cases e.g. thread pool not clearing TLS. Overall, my design was just bad here.
2) Because the range scoped functionality creates state within `SharedReader` that can span multiple reads, without the use of TLS or similar there isn't a reasonable means of guaranteeing thread safety. As such, the internal and external locks have been removed, and the type should be considered thread unsafe. Moving forward, any synchronization will need to occur elsewhere e.g. by locking the `SharedReader` instance itself. However...
3) While I may yet be proven incorrect, I don't foresee any long running operations that warrant thread-level parallelism here. While that may change as we learn more about the file format, thus far it's mostly been the standard stuff--bitwise operations, lookup tables, etc. The only multithreaded stuff I can see happening right now would be UI-related, and that doesn't really justify such a fine-grained approach.