### PR TITLE
Added undocumented flags

### DIFF
--- a/Reemit.Decompiler.Clr.UnitTests/Metadata/Tables/MethodDefRowTests.cs
+++ b/Reemit.Decompiler.Clr.UnitTests/Metadata/Tables/MethodDefRowTests.cs
@@ -212,6 +212,7 @@ public class MethodDefRowTests
         bool expectedIsNoInlining,
         bool expectedIsNoOptimization,
         bool expectedIsMaxMethodImplVal,
+        bool expectedIsAggressiveInlining,
         bool expectedIsStatic,
         bool expectedIsFinal,
         bool expectedIsVirtual,
@@ -253,6 +254,7 @@ public class MethodDefRowTests
         Assert.Equal(expectedIsNoInlining, row.IsNoInlining);
         Assert.Equal(expectedIsNoOptimization, row.IsNoOptimization);
         Assert.Equal(expectedIsMaxMethodImplVal, row.IsMaxMethodImplVal);
+        Assert.Equal(expectedIsAggressiveInlining, row.IsAggressiveInlining);
         Assert.Equal(expectedIsStatic, row.IsStatic);
         Assert.Equal(expectedIsFinal, row.IsFinal);
         Assert.Equal(expectedIsVirtual, row.IsVirtual);
@@ -304,6 +306,7 @@ public class MethodDefRowTests
                 expectedIsNoInlining: false,
                 expectedIsNoOptimization: false,
                 expectedIsMaxMethodImplVal: false,
+                expectedIsAggressiveInlining: false,
                 expectedIsStatic: true,
                 expectedIsFinal: false,
                 expectedIsVirtual: false,
@@ -350,6 +353,54 @@ public class MethodDefRowTests
                 expectedIsNoInlining: false,
                 expectedIsNoOptimization: false,
                 expectedIsMaxMethodImplVal: false,
+                expectedIsAggressiveInlining: false,
+                expectedIsStatic: false,
+                expectedIsFinal: false,
+                expectedIsVirtual: true,
+                expectedIsHideBySig: true,
+                expectedIsStrict: false,
+                expectedIsAbstract: true,
+                expectedIsSpecialName: false,
+                expectedIsPInvokeImpl: false,
+                expectedIsUnmanagedExport: false,
+                expectedIsRTSpecialName: false,
+                expectedHasSecurity: false,
+                expectedRequireSecObject: false),
+            CreateMethodDefTestCase(
+                bytes:
+                [
+                    // RVA
+                    0x00, 0x00, 0x00, 0x00,
+                    
+                    // Impl Flags
+                    0x00, 0x01,
+                    
+                    // Flags
+                    0xc4, 0x05,
+                    
+                    // Other
+                    0x8e, 0x03, 0x10, 0x00, 0x01, 0x00
+                ],
+                expectedRva: 0x0u,
+                expectedImplFlags: 0x100,
+                expectedFlags: 0x05c4,
+                expectedName: 0x38eu,
+                expectedSignature: 0x10u,
+                expectedParamList: 0x1u,
+                expectedCodeType: MethodImplCodeTypeAttributes.IL,
+                expectedManaged: MethodImplManagedAttributes.Managed,
+                expectedMethodImpl: MethodImplAttributes.AggressiveInlining,
+                expectedMethodMemberAccess: MethodMemberAccessAttributes.Family,
+                expectedMethodVtableLayout: MethodVtableLayoutAttributes.NewSlot,
+                expectedMethodFlags: MethodAttributes.Virtual | MethodAttributes.HideBySig | MethodAttributes.Abstract,
+                expectedIsForwardRef: false,
+                expectedIsPreserveSig: false,
+                expectedIsInternalCall: false,
+                expectedIsSynchronized: false,
+                expectedIsNoInlining: false,
+                expectedIsNoOptimization: false,
+                expectedIsMaxMethodImplVal: false,
+                expectedIsAggressiveInlining: true,
                 expectedIsStatic: false,
                 expectedIsFinal: false,
                 expectedIsVirtual: true,
@@ -397,6 +448,7 @@ public class MethodDefRowTests
                 expectedIsNoInlining: false,
                 expectedIsNoOptimization: false,
                 expectedIsMaxMethodImplVal: false,
+                expectedIsAggressiveInlining: false,
                 expectedIsStatic: true,
                 expectedIsFinal: false,
                 expectedIsVirtual: false,
@@ -443,6 +495,7 @@ public class MethodDefRowTests
                 expectedIsNoInlining: true,
                 expectedIsNoOptimization: false,
                 expectedIsMaxMethodImplVal: false,
+                expectedIsAggressiveInlining: false,
                 expectedIsStatic: false,
                 expectedIsFinal: false,
                 expectedIsVirtual: true,
@@ -489,6 +542,7 @@ public class MethodDefRowTests
                 expectedIsNoInlining: true,
                 expectedIsNoOptimization: true,
                 expectedIsMaxMethodImplVal: true,
+                expectedIsAggressiveInlining: true,
                 expectedIsStatic: true,
                 expectedIsFinal: false,
                 expectedIsVirtual: false,
@@ -524,6 +578,7 @@ public class MethodDefRowTests
         bool expectedIsNoInlining,
         bool expectedIsNoOptimization,
         bool expectedIsMaxMethodImplVal,
+        bool expectedIsAggressiveInlining,
         bool expectedIsStatic,
         bool expectedIsFinal,
         bool expectedIsVirtual,
@@ -557,6 +612,7 @@ public class MethodDefRowTests
             expectedIsNoInlining,
             expectedIsNoOptimization,
             expectedIsMaxMethodImplVal,
+            expectedIsAggressiveInlining,
             expectedIsStatic,
             expectedIsFinal,
             expectedIsVirtual,

--- a/Reemit.Decompiler.Clr/Metadata/MethodImplAttributes.cs
+++ b/Reemit.Decompiler.Clr/Metadata/MethodImplAttributes.cs
@@ -16,6 +16,7 @@ public enum MethodImplAttributes : ushort
     // it marked as such anyway.
     MaxMethodImplVal = 0xffff,
     NoOptimization = 0x0040,
+    AggressiveInlining = 0x0100,
 
     // Omitting MaxMethodImplVal from mask
     Mask =
@@ -24,5 +25,6 @@ public enum MethodImplAttributes : ushort
         InternalCall |
         Synchronized |
         NoInlining |
-        NoOptimization
+        NoOptimization |
+        AggressiveInlining
 }

--- a/Reemit.Decompiler.Clr/Metadata/Tables/MethodDefRow.cs
+++ b/Reemit.Decompiler.Clr/Metadata/Tables/MethodDefRow.cs
@@ -45,6 +45,7 @@ public class MethodDefRow(
     public bool IsNoInlining => MethodImpl.HasFlag(MethodImplAttributes.NoInlining);
     public bool IsNoOptimization => MethodImpl.HasFlag(MethodImplAttributes.NoOptimization);
     public bool IsMaxMethodImplVal => (MethodImplAttributes)ImplFlags == MethodImplAttributes.MaxMethodImplVal;
+    public bool IsAggressiveInlining => MethodImpl.HasFlag(MethodImplAttributes.AggressiveInlining);
 
     public bool IsStatic => MethodFlags.HasFlag(MethodAttributes.Static);
     public bool IsFinal => MethodFlags.HasFlag(MethodAttributes.Final);
@@ -144,10 +145,10 @@ public class MethodDefRow(
     }
 
     private static BadImageFormatException CreateWordFlagsImageException(string flagsName, ushort flagsWord) =>
-        throw new BadImageFormatException(
+        new BadImageFormatException(
             $"Invalid {flagsName}: {string.Format("{0:x4}", flagsWord)}.");
 
     private static BadImageFormatException CreateInvalidFlagsImageException(params Enum[] flags) =>
-        throw new BadImageFormatException(
+        new BadImageFormatException(
             $"Invalid flags: {string.Join(", ", flags.Select(x => x.ToString()))}.");
 }

--- a/Reemit.Decompiler.Clr/Metadata/TypeAttributes.cs
+++ b/Reemit.Decompiler.Clr/Metadata/TypeAttributes.cs
@@ -7,6 +7,7 @@ public enum TypeAttributes : uint
     SpecialName = 0x400,
     Import = 0x1000,
     Serializable = 0x2000,
+    WindowsRuntime = 0x4000,
     BeforeFieldInit = 0x100000,
     RTSpecialName = 0x800,
     HasSecurity = 0x40000,
@@ -18,6 +19,7 @@ public enum TypeAttributes : uint
         SpecialName |
         Import |
         Serializable |
+        WindowsRuntime |
         BeforeFieldInit |
         RTSpecialName |
         HasSecurity |

--- a/Reemit.Decompiler.Clr/Metadata/TypeImplementationAttributes.cs
+++ b/Reemit.Decompiler.Clr/Metadata/TypeImplementationAttributes.cs
@@ -7,8 +7,10 @@ public enum TypeImplementationAttributes : ushort
 {
     Import = 0x1000,
     Serializable = 0x2000,
-    
+    WindowsRuntime = 0x4000,
+
     Mask = 
         Import |
-        Serializable
+        Serializable |
+        WindowsRuntime
 }


### PR DESCRIPTION
This PR adds the undocumented windows runtime and aggressive inlining flags. Following the convention of other `MethodImplAttributes` flags, the `IsAggressiveInlining` property was added to `MethodDefRow`. Test coverage was expanded to cover this new property. 